### PR TITLE
Invalidate submission helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ This is a convenience function to change the status of a submission
 challengeutils changestatus 1234545 INVALID
 ```
 
+**Making WorkflowHook submission invalid**
+
+The challenge workflow templates and workflow hooks together add a 'prediction_file_status' to the submission but makes the submission status 'ACCEPTED'. This is an issue because the submission status is used for synapse submission quotas.  This function will check the 'prediction_file_status'. If it is 'INVALID' make the submission status 'INVALID' as well.
+
+```
+challengeutils makehooksubinvalid 999999
+```
+
 **Attaching write ups to main submission queue**
 
 Most challenges require participants to submit a writeup.  Using the new archive-challenge-project-tool system of receiving writeups, this is a convenience function to merge the writeup and archived write up Synapse ids to the main challenge queue

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -60,6 +60,10 @@ def command_dl_cur_lead_sub(syn, args):
         verbose=args.verbose)
 
 
+def command_make_hook_sub_invalid(syn, args):
+    helpers.make_submission_status_invalid(syn, args.evaluationid)
+
+
 def build_parser():
     """Builds the argument parser and returns the result."""
     parser = argparse.ArgumentParser(
@@ -153,6 +157,14 @@ def build_parser():
         help='Status to change submission to')
 
     parser_change_status.set_defaults(func=command_change_status)
+
+    parser_make_sub_invalid = subparsers.add_parser('makehooksubinvalid',
+                                                    help='Changes submission status with invalid prediction file to invalid')
+    parser_make_sub_invalid.add_argument("evaluationid",
+                                         type=str,
+                                         help="Synapse evaluation id")
+
+    parser_make_sub_invalid.set_defaults(func=command_make_hook_sub_invalid)
 
     parser_attach_writeup = subparsers.add_parser(
         'attachwriteup',

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -7,6 +7,7 @@ from . import utils
 from . import writeup_attacher
 from . import permissions
 from . import download_current_lead_submission as dl_cur
+from . import helpers
 
 
 def command_mirrorwiki(syn, args):

--- a/challengeutils/helpers.py
+++ b/challengeutils/helpers.py
@@ -98,8 +98,7 @@ def kill_docker_submission_over_quota(syn, evaluation_id, quota=None):
     time_remaining_key = "org.sagebionetworks.SynapseWorkflowHook.TimeRemaining"
 
     evaluation_query = "select * from evaluation_{} where status == 'EVALUATION_IN_PROGRESS'".format(evaluation_id)
-    query_results = \
-        utils.evaluation_queue_query(syn, evaluation_query)
+    query_results = utils.evaluation_queue_query(syn, evaluation_query)
 
     for result in query_results:
         last_updated = int(result[workflow_last_updated_key])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,21 @@
+from mock import patch
+import synapseclient
+import challengeutils.helpers
+import challengeutils.utils
+EVALUATION_ID = 111111
+OBJECTID = "99999"
+syn = synapseclient.Synapse()
+
+
+def test_make_submission_status_invalid():
+    uri = ("select objectId from evaluation_{evalid} "
+           "where status == 'ACCEPTED' and "
+           "prediction_file_status == 'INVALID'".format(evalid=EVALUATION_ID))
+    with patch.object(challengeutils.utils,
+                      "evaluation_queue_query",
+                      return_value=[{"objectId": OBJECTID}]) as patch_eval_queue,\
+        patch.object(challengeutils.utils,
+                     "change_submission_status") as patch_change_status:
+        challengeutils.helpers.make_submission_status_invalid(syn, EVALUATION_ID)
+        patch_eval_queue.assert_called_once_with(syn, uri)
+        patch_change_status.assert_called_once_with(syn, OBJECTID, 'INVALID')


### PR DESCRIPTION
The challenge workflow templates and workflow hooks together add a 'prediction_file_status' to the submission but makes the submission status 'ACCEPTED'. This is an issue because the submission status is used for synapse submission quotas.  This function will check the 'prediction_file_status'. If it is 'INVALID' make the submission status 'INVALID' as well.