### PR TITLE
Terminate docker submission over the runtime quota

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_install:
 matrix:
   include:
     - os: linux
-      python: 3.5.3
-    - os: linux
       python: 3.6
+    - os: linux
+      python: 3.7

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -11,6 +11,7 @@ from . import utils
 from . import writeup_attacher
 from . import permissions
 from . import download_current_lead_submission as dl_cur
+from . import helpers
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,15 @@ def command_annotate_submission_with_json(syn, args):
         force_change_annotation_acl=args.force_change_annotation_acl),
         wait=3,
         retries=10)
+
+
+def command_kill_docker_over_quota(syn, args):
+    '''
+    Command line helper to kill docker submissions
+    over the quota
+    '''
+    helpers.kill_docker_submission_over_quota(syn, args.evaluationid,
+                                              quota=args.quota)
 
 
 def build_parser():
@@ -326,6 +336,22 @@ def build_parser():
         action='store_true')
     parser_annotate_sub.set_defaults(
         func=command_annotate_submission_with_json)
+
+
+    parser_kill_docker = subparsers.add_parser(
+        'killdockeroverquota',
+        help='Kill Docker submissions over the quota')
+
+    parser_kill_docker.add_argument(
+        "evaluationid",
+        type=str,
+        help='Synapse evaluation queue id')
+
+    parser_kill_docker.add_argument(
+        "quota",
+        type=int,
+        help="Time quota submission has to run in milliseconds")
+    parser_kill_docker.set_defaults(func=command_kill_docker_over_quota)
 
     return parser
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,110 @@
+'''
+Test challengeutils helper functions
+'''
+import mock
+from mock import patch
+from challengeutils import helpers, utils
+import synapseclient
+from synapseclient.annotations import to_submission_status_annotations
+
+SYN = mock.create_autospec(synapseclient.Synapse)
+WORKFLOWHOOK_KEY = "org.sagebionetworks.SynapseWorkflowHook"
+WORKFLOW_LAST_UPDATED_KEY = f"{WORKFLOWHOOK_KEY}.WorkflowLastUpdated"
+WORKFLOW_START_KEY = f"{WORKFLOWHOOK_KEY}.ExecutionStarted"
+TIME_REMAINING_KEY = f"{WORKFLOWHOOK_KEY}.TimeRemaining"
+LAST_UPDATED_TIME = 1000000
+START_TIME = 10000
+DOCKER_SUB_ANNOTATION = {WORKFLOW_LAST_UPDATED_KEY: LAST_UPDATED_TIME,
+                         WORKFLOW_START_KEY: START_TIME,
+                         'objectId':"12345"}
+EVALUATION_ID = 111
+
+def test_noquota_kill_docker_submission_over_quota():
+    '''
+    Test if no quota is set
+    '''
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[DOCKER_SUB_ANNOTATION]) as patch_query,\
+         patch.object(SYN,
+                      "getSubmissionStatus") as patch_getstatus,\
+         patch.object(utils,
+                      "update_single_submission_status") as patch_update, \
+         patch.object(SYN, "store") as patch_synstore:
+        helpers.kill_docker_submission_over_quota(SYN, EVALUATION_ID)
+        query = ("select * from evaluation_{} where "
+                 "status == 'EVALUATION_IN_PROGRESS'").format(EVALUATION_ID)
+        patch_query.assert_called_once_with(SYN, query)
+        patch_getstatus.assert_not_called()
+        patch_update.assert_not_called()
+        patch_synstore.assert_not_called()
+
+
+def test_notdocker_kill_docker_submission_over_quota():
+    '''
+    Test if not a submission ran through the workflowhook
+    the submission will not have the right annotations
+    '''
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[{}]) as patch_query,\
+         patch.object(SYN,
+                      "getSubmissionStatus") as patch_getstatus,\
+         patch.object(utils,
+                      "update_single_submission_status") as patch_update, \
+         patch.object(SYN, "store") as patch_synstore:
+        helpers.kill_docker_submission_over_quota(SYN, EVALUATION_ID)
+        query = ("select * from evaluation_{} where "
+                 "status == 'EVALUATION_IN_PROGRESS'").format(EVALUATION_ID)
+        patch_query.assert_called_once_with(SYN, query)
+        patch_getstatus.assert_not_called()
+        patch_update.assert_not_called()
+        patch_synstore.assert_not_called()
+
+
+def test_underquota_kill_docker_submission_over_quota():
+    '''
+    Test if the model is not over quota
+    '''
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[DOCKER_SUB_ANNOTATION]) as patch_query,\
+         patch.object(SYN,
+                      "getSubmissionStatus") as patch_getstatus,\
+         patch.object(utils,
+                      "update_single_submission_status") as patch_update, \
+         patch.object(SYN, "store") as patch_synstore:
+        # Set quota thats greater than the runtime
+        quota = LAST_UPDATED_TIME - START_TIME + 9000
+        helpers.kill_docker_submission_over_quota(SYN, EVALUATION_ID,
+                                                  quota=quota)
+        query = ("select * from evaluation_{} where "
+                 "status == 'EVALUATION_IN_PROGRESS'").format(EVALUATION_ID)
+        patch_query.assert_called_once_with(SYN, query)
+        patch_getstatus.assert_not_called()
+        patch_update.assert_not_called()
+        patch_synstore.assert_not_called()
+
+
+def test_overquota_kill_docker_submission_over_quota():
+    '''
+    Test if the model is over the quota
+    '''
+    sub_status = {"annotations": []}
+    quota_over_annotations = {TIME_REMAINING_KEY: 0}
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[DOCKER_SUB_ANNOTATION]) as patch_query,\
+         patch.object(SYN, "getSubmissionStatus",
+                      return_value=sub_status) as patch_getstatus,\
+         patch.object(utils, "update_single_submission_status",
+                      return_value=sub_status) as patch_update, \
+         patch.object(SYN, "store") as patch_synstore:
+        # Set quota thats lower than the runtime
+        quota = LAST_UPDATED_TIME - START_TIME - 9000
+        helpers.kill_docker_submission_over_quota(SYN, EVALUATION_ID,
+                                                  quota=quota)
+        query = ("select * from evaluation_{} where "
+                 "status == 'EVALUATION_IN_PROGRESS'").format(EVALUATION_ID)
+        patch_query.assert_called_once_with(SYN, query)
+        objectid = DOCKER_SUB_ANNOTATION['objectId']
+        patch_getstatus.assert_called_once_with(objectid)
+        patch_update.assert_called_once_with(sub_status,
+                                             quota_over_annotations)
+        patch_synstore.assert_called_once_with(sub_status)


### PR DESCRIPTION
* Add in complete test suite

In model to data challenges, we want to enforce runtime quota on models that are submitted to us.  The SynapseWorkflowHook by default does not track the runtime of each submission, but adds a execute start and last updated time to each submission as annotations.  A separate tool (this tool) queries the evaluation queue, and calculates the runtime per submission, determining whether or not the submission has reached the runtime quota.  If it has, this tool creates a submission status annotation `{"...timeremaining":0}`.

The SynapseWorkflowHook looks for the submission annotation {"...timeremaining":0} and kills the docker submission that is running.
