### PR TITLE
Make annotate submission its own function

### DIFF
--- a/challengeutils/project_submission.py
+++ b/challengeutils/project_submission.py
@@ -148,31 +148,6 @@ def join_queues(syn, queue1, queue2, joinby, how="inner"):
 #     return subs_and_writeupsdf
 
 
-def annotate_submission(syn, submissionid, annotation_dict,
-                        to_public=False,
-                        force_change_annotation_acl=False):
-    """
-    Annotate submission with annotation values from a dict
-    Args:
-        syn: Synapse object
-        submissionid: Submission id
-        annotation_dict: Annotation dict
-        to_public: change these annotations from private to public
-                   (default is False)
-        force_change_annotation_acl: Force change the annotation from
-                                     private to public and vice versa.
-    """
-    status = syn.getSubmissionStatus(submissionid)
-    # Don't add any annotations that are None
-    annotation_dict = {key: annotation_dict[key] for key in annotation_dict
-                       if annotation_dict[key] is not None}
-    status = utils.update_single_submission_status(
-        status, annotation_dict,
-        to_public=to_public,
-        force_change_annotation_acl=force_change_annotation_acl)
-    status = syn.store(status)
-
-
 def archive_and_attach_project_submissions(syn, writeup_queueid,
                                            submission_queueid,
                                            status_key="STATUS"):
@@ -238,8 +213,8 @@ def archive_and_attach_project_submissions(syn, writeup_queueid,
 
     # objectId_x: objectIds from submission queue
     subs_and_writeupsdf.apply(lambda row:
-                              annotate_submission(syn,
-                                                  row['objectId_x'],
-                                                  row[annotation_keys],
-                                                  annotation_keys),
+                              utils.annotate_submission(syn,
+                                                        row['objectId_x'],
+                                                        row[annotation_keys],
+                                                        annotation_keys),
                               axis=1)

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -491,7 +491,7 @@ def annotate_submission_with_json(syn, submissionid, annotation_values,
 
 def annotate_submission(syn, submissionid, annotation_dict,
                         to_public=False,
-                        force_change_annotation_acl=False):
+                        force=False):
     """
     Annotate submission with annotation values from a dict
 

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -467,8 +467,7 @@ def download_submission(syn, submissionid, download_location=None):
 
 
 def annotate_submission_with_json(syn, submissionid, annotation_values,
-                                  to_public=False,
-                                  force_change_annotation_acl=False):
+                                  **kwargs):
     """
     Annotate submission with annotation values from a json file
 
@@ -478,20 +477,16 @@ def annotate_submission_with_json(syn, submissionid, annotation_values,
         annotation_values: Annotation json file
         to_public: change these annotations from private to public
                    (default is False)
-        force_change_annotation_acl: Force change the annotation from
-                                     private to public and vice versa.
+        force: Force change the annotation from private to public and
+               vice versa.
     """
     with open(annotation_values) as json_data:
         annotation_json = json.load(json_data)
-    annotate_submission(
-        syn, submissionid, annotation_json,
-        to_public=to_public,
-        force_change_annotation_acl=force_change_annotation_acl)
+    annotate_submission(syn, submissionid, annotation_json, **kwargs)
 
 
 def annotate_submission(syn, submissionid, annotation_dict,
-                        to_public=False,
-                        force=False):
+                        to_public=False, force=False):
     """
     Annotate submission with annotation values from a dict
 
@@ -501,8 +496,8 @@ def annotate_submission(syn, submissionid, annotation_dict,
         annotation_dict: Annotation dict
         to_public: change these annotations from private to public
                    (default is False)
-        force_change_annotation_acl: Force change the annotation from
-                                     private to public and vice versa.
+        force: Force change the annotation from private to public and
+               vice versa.
     """
     status = syn.getSubmissionStatus(submissionid)
     # Don't add any annotations that are None
@@ -511,5 +506,5 @@ def annotate_submission(syn, submissionid, annotation_dict,
     status = update_single_submission_status(
         status, annotation_dict,
         to_public=to_public,
-        force_change_annotation_acl=force_change_annotation_acl)
+        force_change_annotation_acl=force)
     status = syn.store(status)

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -469,7 +469,7 @@ def download_submission(syn, submissionid, download_location=None):
 def annotate_submission_with_json(syn, submissionid, annotation_values,
                                   to_public=False,
                                   force_change_annotation_acl=False):
-    '''
+    """
     Annotate submission with annotation values from a json file
 
     Args:
@@ -480,12 +480,36 @@ def annotate_submission_with_json(syn, submissionid, annotation_values,
                    (default is False)
         force_change_annotation_acl: Force change the annotation from
                                      private to public and vice versa.
-    '''
-    status = syn.getSubmissionStatus(submissionid)
+    """
     with open(annotation_values) as json_data:
         annotation_json = json.load(json_data)
+    annotate_submission(
+        syn, submissionid, annotation_json,
+        to_public=to_public,
+        force_change_annotation_acl=force_change_annotation_acl)
+
+
+def annotate_submission(syn, submissionid, annotation_dict,
+                        to_public=False,
+                        force_change_annotation_acl=False):
+    """
+    Annotate submission with annotation values from a dict
+
+    Args:
+        syn: Synapse object
+        submissionid: Submission id
+        annotation_dict: Annotation dict
+        to_public: change these annotations from private to public
+                   (default is False)
+        force_change_annotation_acl: Force change the annotation from
+                                     private to public and vice versa.
+    """
+    status = syn.getSubmissionStatus(submissionid)
+    # Don't add any annotations that are None
+    annotation_dict = {key: annotation_dict[key] for key in annotation_dict
+                       if annotation_dict[key] is not None}
     status = update_single_submission_status(
-        status, annotation_json,
+        status, annotation_dict,
         to_public=to_public,
         force_change_annotation_acl=force_change_annotation_acl)
     status = syn.store(status)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,7 +191,7 @@ def test_annotate_submission():
         challengeutils.utils.annotate_submission(
             syn, "1234", to_add_annotations,
             to_public=False,
-            force_change_annotation_acl=False)
+            force=False)
         patch_get_submission.assert_called_once_with("1234")
         patch_update.assert_called_once_with(
             status, added_annotations,
@@ -211,8 +211,8 @@ def test_annotate_submission_with_json():
         challengeutils.utils.annotate_submission_with_json(
             syn, "1234", tmp.name,
             to_public=False,
-            force_change_annotation_acl=False)
+            force=False)
         patch_annotate.assert_called_once_with(
             syn, "1234", add_annotations,
             to_public=False,
-            force_change_annotation_acl=False)
+            force=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 import re
 import challengeutils.utils
 import synapseclient
+import tempfile
 from synapseclient.annotations import to_submission_status_annotations
 
 syn = mock.create_autospec(synapseclient.Synapse)
@@ -175,27 +176,43 @@ def test_specifyloc_download_submission():
         assert sub_dict == expected_submission_dict
 
 
-def test_annotate_submission_with_json():
-    add_annotations = {'test': 2, 'test2': 2}
-    tempfile_path = "temp.json"
-    with open(tempfile_path, "w") as annotation_file:
-        json.dump(add_annotations, annotation_file)
+def test_annotate_submission():
+    """Annotate submission with dict.  Make sure annotation values of None
+    aren't added"""
+    to_add_annotations = {'test': 2, 'test2': 2, 'notnone': None}
     status = {"foo": "bar"}
-    with mock.patch.object(
-            syn, "getSubmissionStatus",
-            return_value=status) as patch_get_submission, \
-        mock.patch.object(
-            challengeutils.utils, "update_single_submission_status",
-            return_value=status) as patch_update, \
-            mock.patch.object(syn, "store") as patch_syn_store:
-        challengeutils.utils.annotate_submission_with_json(
-            syn, "1234", tempfile_path,
+    added_annotations = {'test': 2, 'test2': 2}
+    with mock.patch.object(syn, "getSubmissionStatus",
+                           return_value=status) as patch_get_submission, \
+         mock.patch.object(challengeutils.utils,
+                           "update_single_submission_status",
+                           return_value=status) as patch_update, \
+         mock.patch.object(syn, "store") as patch_syn_store:
+        challengeutils.utils.annotate_submission(
+            syn, "1234", to_add_annotations,
             to_public=False,
             force_change_annotation_acl=False)
         patch_get_submission.assert_called_once_with("1234")
         patch_update.assert_called_once_with(
-            status, add_annotations,
+            status, added_annotations,
             to_public=False,
             force_change_annotation_acl=False)
         patch_syn_store.assert_called_once_with(status)
-    os.unlink(tempfile_path)
+
+
+def test_annotate_submission_with_json():
+    """Annotate submission with json should call annotate submission"""
+    add_annotations = {'test': 2, 'test2': 2}
+    tmp = tempfile.NamedTemporaryFile()
+    with open(tmp.name, "w") as annotation_file:
+        json.dump(add_annotations, annotation_file)
+    with mock.patch.object(challengeutils.utils,
+                           "annotate_submission") as patch_annotate:
+        challengeutils.utils.annotate_submission_with_json(
+            syn, "1234", tmp.name,
+            to_public=False,
+            force_change_annotation_acl=False)
+        patch_annotate.assert_called_once_with(
+            syn, "1234", add_annotations,
+            to_public=False,
+            force_change_annotation_acl=False)


### PR DESCRIPTION
Annotate submission with json used to be its own function.  Abstracted out the part where the annotation of the function was happening.