### PR TITLE
Lint and add tests for dl cur

### DIFF
--- a/challengeutils/download_current_lead_submission.py
+++ b/challengeutils/download_current_lead_submission.py
@@ -22,7 +22,7 @@ def get_submitterid_from_submission_id(syn, submissionid, queue,
     generator = utils.evaluation_queue_query(syn, query)
     lst = list(generator)
     if not lst:
-        raise Exception('submission id {} not in queue'.format(submissionid))
+        raise ValueError('submission id {} not in queue'.format(submissionid))
     submission_dict = lst[0]
     submitterid = submission_dict['submitterId']
     if verbose:

--- a/challengeutils/download_current_lead_submission.py
+++ b/challengeutils/download_current_lead_submission.py
@@ -1,5 +1,6 @@
 """Download the current leading submission for boot ladder boot method"""
 import os
+
 from . import utils
 
 

--- a/challengeutils/download_current_lead_submission.py
+++ b/challengeutils/download_current_lead_submission.py
@@ -1,51 +1,86 @@
+"""Download the current leading submission for boot ladder boot method"""
 import os
 from . import utils
 
 
 def get_submitterid_from_submission_id(syn, submissionid, queue,
                                        verbose=False):
-    query = ("select * from " + queue +
-             " where objectId == " + str(submissionid))
+    """Gets submitterid from submission id
+
+    Args:
+        syn: Synapse connection
+        submissionid: Submission id
+        queue: Evaluation queue id
+        verbose: Boolean value to print
+
+    Returns:
+        Submitter id
+    """
+    query = ("select submitterId from evaluation_{} "
+             "where objectId == '{}'".format(queue, submissionid))
     generator = utils.evaluation_queue_query(syn, query)
     lst = list(generator)
-    if len(lst) == 0:
+    if not lst:
         raise Exception('submission id {} not in queue'.format(submissionid))
     submission_dict = lst[0]
     submitterid = submission_dict['submitterId']
     if verbose:
         print("submitterid: " + submitterid)
-    return(submitterid)
+    return submitterid
 
 
 def get_submitters_lead_submission(syn, submitterid, queue,
                                    cutoff_annotation, verbose=False):
-    query = ("select * from " + queue +
-             " where submitterId == " + str(submitterid) +
-             " and prediction_file_status == 'SCORED' and '" +
-             cutoff_annotation + "' == 'true'" +
-             " order by createdOn DESC")
+    """Gets submitter's lead submission
+
+    Args:
+        submitterid: Submitter id
+        queue: Evaluation queue id
+        cutoff_annotation: Boolean cutoff annotation key
+        verbose: Boolean value to print
+
+    Returns:
+        previous_submission.csv or None
+    """
+    query = ("select objectId from evaluation_{} where submitterId == '{}' "
+             "and prediction_file_status == 'SCORED' and {} == 'true' "
+             "order by createdOn DESC".format(queue, submitterid,
+                                              cutoff_annotation))
+
     generator = utils.evaluation_queue_query(syn, query)
     lst = list(generator)
-    if len(lst) > 0:
+    if lst:
         sub_dict = lst[0]
         objectid = sub_dict['objectId']
         if verbose:
             print("Dowloading submissionid: " + objectid)
         sub = syn.getSubmission(objectid, downloadLocation=".")
         os.rename(sub.filePath, "previous_submission.csv")
-        return("previous_submission.csv")
-    else:
-        print("Downloading no file")
+        return "previous_submission.csv"
+    print("Downloading no file")
+    return None
 
 
 def download_current_lead_sub(syn, submissionid, status,
                               cutoff_annotation, verbose=False):
+    """Downloads current leading submission
+
+    Args:
+        syn: Synapse connection
+        submissionid: Submission id
+        status: Submission status
+        cutoff_annotation: Boolean cutoff annotation key
+        verbose: Boolean value to print
+
+    Returns:
+        Path to current leading submission or None
+    """
     if status == "VALIDATED":
         current_sub = syn.getSubmission(submissionid, downloadFile=False)
         queue_num = current_sub['evaluationId']
-        queue = "evaluation_" + queue_num
-        submitterid = get_submitterid_from_submission_id(
-            syn, submissionid, queue, verbose)
-        path = get_submitters_lead_submission(
-            syn, submitterid, queue, cutoff_annotation, verbose)
-        return(path)
+        submitterid = get_submitterid_from_submission_id(syn, submissionid,
+                                                         queue_num, verbose)
+        path = get_submitters_lead_submission(syn, submitterid, queue_num,
+                                              cutoff_annotation, verbose)
+        return path
+    return None

--- a/tests/test_download_current_lead_submission.py
+++ b/tests/test_download_current_lead_submission.py
@@ -77,16 +77,13 @@ def test_download_current_lead_sub():
     """Tests download of lead submission"""
     submission = synapseclient.Submission(evaluationId='2', entityId='2',
                                           versionNumber='3')
-
-
     with patch.object(SYN, "getSubmission",
-                     return_value=submission) as patch_getsub,\
+                      return_value=submission) as patch_getsub,\
         patch.object(dl_cur, "get_submitterid_from_submission_id",
                      return_value="2") as patch_getsubmitter,\
         patch.object(dl_cur, "get_submitters_lead_submission",
                      return_value="path") as patch_get_lead:
-        dl_file = dl_cur.download_current_lead_sub(SYN,
-                                                   SUBMISSIONID,
+        dl_file = dl_cur.download_current_lead_sub(SYN, SUBMISSIONID,
                                                    "VALIDATED",
                                                    "key",
                                                    verbose=False)

--- a/tests/test_download_current_lead_submission.py
+++ b/tests/test_download_current_lead_submission.py
@@ -61,7 +61,7 @@ def test_get_submitters_lead_submission():
 
 
 def test_none_get_submitters_lead_submission():
-    """Tests getting of submitter id"""
+    """Tests not getting submission"""
     with patch.object(utils, "evaluation_queue_query",
                       return_value=[]) as patch_query:
         dl_file = dl_cur.get_submitters_lead_submission(SYN,
@@ -71,3 +71,33 @@ def test_none_get_submitters_lead_submission():
                                                         verbose=False)
         patch_query.assert_called_once()
         assert dl_file is None
+
+
+def test_download_current_lead_sub():
+    """Tests download of lead submission"""
+    submission = synapseclient.Submission(evaluationId='2', entityId='2',
+                                          versionNumber='3')
+
+
+    with patch.object(SYN, "getSubmission",
+                     return_value=submission) as patch_getsub,\
+        patch.object(dl_cur, "get_submitterid_from_submission_id",
+                     return_value="2") as patch_getsubmitter,\
+        patch.object(dl_cur, "get_submitters_lead_submission",
+                     return_value="path") as patch_get_lead:
+        dl_file = dl_cur.download_current_lead_sub(SYN,
+                                                   SUBMISSIONID,
+                                                   "VALIDATED",
+                                                   "key",
+                                                   verbose=False)
+        patch_getsubmitter.assert_called_once()
+        patch_get_lead.assert_called_once()
+        assert dl_file == "path"
+
+
+def test_invalid_download_current_lead_sub():
+    """Tests None is downloaded if status is INVALID"""
+    dl_file = dl_cur.download_current_lead_sub(SYN, SUBMISSIONID,
+                                               "INVALID", "key",
+                                               verbose=False)
+    assert dl_file is None

--- a/tests/test_download_current_lead_submission.py
+++ b/tests/test_download_current_lead_submission.py
@@ -1,0 +1,36 @@
+"""Test download current lead submission"""
+import mock
+from mock import patch
+import pytest
+
+import synapseclient
+
+from challengeutils import utils
+import challengeutils.download_current_lead_submission as dl_cur
+
+SYN = mock.create_autospec(synapseclient.Synapse)
+SUBMISSIONID = "111"
+QUEUEID = "333"
+
+
+def test_nosub_get_submitterid_from_submission_id():
+    """Tests if submission id doesn't exist"""
+    with pytest.raises(ValueError,
+                       match=r'submission id*'),\
+        patch.object(utils, "evaluation_queue_query",
+                     return_value=[]) as patch_query:
+        dl_cur.get_submitterid_from_submission_id(SYN, SUBMISSIONID, QUEUEID,
+                                                  verbose=False)
+        patch_query.assert_called_once()
+
+
+def test_get_submitterid_from_submission_id():
+    """Tests getting of submitter id"""
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[{'submitterId': 1}]) as patch_query:
+        submitter = dl_cur.get_submitterid_from_submission_id(SYN,
+                                                              SUBMISSIONID,
+                                                              QUEUEID,
+                                                              verbose=False)
+        patch_query.assert_called_once()
+        assert submitter == 1

--- a/tests/test_download_current_lead_submission.py
+++ b/tests/test_download_current_lead_submission.py
@@ -1,8 +1,10 @@
 """Test download current lead submission"""
+import os
+import tempfile
+
 import mock
 from mock import patch
 import pytest
-
 import synapseclient
 
 from challengeutils import utils
@@ -34,3 +36,38 @@ def test_get_submitterid_from_submission_id():
                                                               verbose=False)
         patch_query.assert_called_once()
         assert submitter == 1
+
+
+def test_get_submitters_lead_submission():
+    """Tests getting of lead submission"""
+    submission = synapseclient.Submission(evaluationId='2', entityId='2',
+                                          versionNumber='3')
+    temp = tempfile.NamedTemporaryFile()
+    submission.filePath = temp.name
+
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[{'objectId': 1}]) as patch_query,\
+        patch.object(SYN, "getSubmission",
+                     return_value=submission) as patch_getsub:
+        dl_file = dl_cur.get_submitters_lead_submission(SYN,
+                                                        SUBMISSIONID,
+                                                        QUEUEID,
+                                                        "key",
+                                                        verbose=False)
+        patch_query.assert_called_once()
+        patch_getsub.assert_called_once_with(1, downloadLocation='.')
+        assert dl_file == "previous_submission.csv"
+        os.unlink("previous_submission.csv")
+
+
+def test_none_get_submitters_lead_submission():
+    """Tests getting of submitter id"""
+    with patch.object(utils, "evaluation_queue_query",
+                      return_value=[]) as patch_query:
+        dl_file = dl_cur.get_submitters_lead_submission(SYN,
+                                                        SUBMISSIONID,
+                                                        QUEUEID,
+                                                        "key",
+                                                        verbose=False)
+        patch_query.assert_called_once()
+        assert dl_file is None


### PR DESCRIPTION
The purpose of this function is for the boot ladder boot workflow.  This workflow is when organizers want to get the most current leading submission from a participant and compare it with the RECEIVED submission.   The function here obtains the most current leading submission.