### PR TITLE
Fix exponential backoff when storing submission status

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -100,10 +100,10 @@ def command_download_submission(syn, args):
 
 
 def command_annotate_submission_with_json(syn, args):
-    _with_retry(lambda: utils.annotate_submission_with_json(syn, args.submissionid,
-                                                            args.annotation_values,  # pylint: disable=line-too-long
-                                                            to_public=args.to_public,  # pylint: disable=line-too-long
-                                                            force_change_annotation_acl=args.force_change_annotation_acl),  # pylint: disable=line-too-long
+    _with_retry(lambda: utils.annotate_submission_with_json(syn, args.submissionid,  # noqa pylint: disable=line-too-long
+                                                            args.annotation_values,  # noqa pylint: disable=line-too-long
+                                                            to_public=args.to_public,  # noqa pylint: disable=line-too-long
+                                                            force_change_annotation_acl=args.force_change_annotation_acl),  # noqa pylint: disable=line-too-long
                 wait=3,
                 retries=10,
                 retry_status_codes=[412, 429, 500, 502, 503, 504],

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -100,13 +100,14 @@ def command_download_submission(syn, args):
 
 
 def command_annotate_submission_with_json(syn, args):
-    _with_retry(lambda: utils.annotate_submission_with_json(
-        syn, args.submissionid,
-        args.annotation_values,
-        to_public=args.to_public,
-        force_change_annotation_acl=args.force_change_annotation_acl),
-        wait=3,
-        retries=10)
+    _with_retry(lambda: utils.annotate_submission_with_json(syn, args.submissionid,
+                                                            args.annotation_values,  # pylint: disable=line-too-long
+                                                            to_public=args.to_public,  # pylint: disable=line-too-long
+                                                            force_change_annotation_acl=args.force_change_annotation_acl),  # pylint: disable=line-too-long
+                wait=3,
+                retries=10,
+                retry_status_codes=[412, 429, 500, 502, 503, 504],
+                verbose=True)
 
 
 def command_send_email(syn, args):

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -593,11 +593,19 @@ def download_submission(syn, submissionid, download_location=None):
     return result
 
 
+class mock_response:
+    """Mocked status code to return"""
+    status_code = 200
+
+
 def annotate_submission_with_json(syn, submissionid, annotation_values,
                                   to_public=False,
                                   force_change_annotation_acl=False):
     '''
-    Annotate submission with annotation values from a json file
+    ChallengeWorkflowTemplate tool: Annotates submission with annotation
+    values from a json file and uses exponential backoff to retry when
+    there are concurrent update issues (HTTP 412).  Must return a object
+    with status_code that has a range between 200-209
 
     Args:
         syn: Synapse object
@@ -607,15 +615,18 @@ def annotate_submission_with_json(syn, submissionid, annotation_values,
                    (default is False)
         force_change_annotation_acl: Force change the annotation from
                                      private to public and vice versa.
+
+    Returns:
+        mocked response object (200)
     '''
     status = syn.getSubmissionStatus(submissionid)
     with open(annotation_values) as json_data:
         annotation_json = json.load(json_data)
-    status = update_single_submission_status(
-        status, annotation_json,
-        to_public=to_public,
-        force_change_annotation_acl=force_change_annotation_acl)
+    status = update_single_submission_status(status, annotation_json,
+                                             to_public=to_public,
+                                             force_change_annotation_acl=force_change_annotation_acl)  # pylint: disable=line-too-long
     status = syn.store(status)
+    return mock_response
 
 
 def _get_submitter_name(syn, submitterid):

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -624,7 +624,7 @@ def annotate_submission_with_json(syn, submissionid, annotation_values,
         annotation_json = json.load(json_data)
     status = update_single_submission_status(status, annotation_json,
                                              to_public=to_public,
-                                             force_change_annotation_acl=force_change_annotation_acl)  # pylint: disable=line-too-long
+                                             force_change_annotation_acl=force_change_annotation_acl)  # noqa pylint: disable=line-too-long
     status = syn.store(status)
     return mock_response
 


### PR DESCRIPTION
* 412 error code wasn't being caught
* add verbose = True to view logs