### PR TITLE
Return challenge component URLs after creation

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -66,7 +66,7 @@ def command_createchallenge(syn, args):
             "{name} (Participant team): {organizer_teamid}",
             "{name} (Organizer team): {participant_teamid}",
             "{name} (Pre-registrant team): {preregistrantrant_teamid}")
-    print("\n"+ "\n".join(text).format(**urls))
+    print("\n" + "\n".join(text).format(**urls))
     return challenge_components
 
 def command_query(syn, args):

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -8,7 +8,7 @@ import pandas as pd
 import synapseclient
 
 try:
-    from synapseclient.core.retry import _with_retry
+    from synapseclient.core.retry import with_retry as _with_retry
 except ModuleNotFoundError:
     # For synapseclient < v2.0
     from synapseclient.retry import _with_retry
@@ -49,8 +49,25 @@ def command_createchallenge(syn, args):
 
     >>> challengeutils createchallenge "Challenge Name Here"
     """
-    createchallenge.main(syn, args.challengename, args.livesiteid)
-
+    challenge_components = createchallenge.main(syn, args.challengename,
+                                                args.livesiteid)
+    # component: project or team
+    # componentid: project id or teamid
+    urls = {}
+    for component, componentid in challenge_components.items():
+        if component.endswith("projectid"):
+            urls[component] = f"https://www.synapse.org/#!Synapse:{componentid}"
+        elif component.endswith("teamid"):
+            urls[component] = f"https://www.synapse.org/#!Team:{componentid}"
+    urls['name'] = args.challengename
+    text = ("{name} (Production site): {live_projectid}",
+            "{name} (Staging site): {staging_projectid}",
+            "{name} (Admin team): {admin_teamid}",
+            "{name} (Participant team): {organizer_teamid}",
+            "{name} (Organizer team): {participant_teamid}",
+            "{name} (Pre-registrant team): {preregistrantrant_teamid}")
+    print("\n"+ "\n".join(text).format(**urls))
+    return challenge_components
 
 def command_query(syn, args):
     """Command line convenience function to call evaluation queue query

--- a/challengeutils/createchallenge.py
+++ b/challengeutils/createchallenge.py
@@ -258,6 +258,15 @@ def main(syn, challenge_name, live_site=None):
         challenge_name: Name of the challenge
         live_site: If there is already a live site, specify live site Synapse
                    id. (Default is None)
+
+    Returns:
+        dict: {"live_projectid": projectid,
+               "staging_projectid": projectid,
+               "admin_teamid": teams['team_admin_id'],
+               "organizer_teamid": teams['team_org_id'],
+               "participant_teamid": teams['team_part_id'],
+               "preregistrantrant_teamid": teams['team_prereg_id']}
+
     """
     # Create teams for challenge sites
     teams = _create_teams(syn, challenge_name)
@@ -303,3 +312,9 @@ def main(syn, challenge_name, live_site=None):
                                                     challenge_name,
                                                     project_live.id)
         syn.store(wikipage)
+    return {"live_projectid": project_live.id,
+            "staging_projectid": project_staging.id,
+            "admin_teamid": teams['team_admin_id'],
+            "organizer_teamid": teams['team_org_id'],
+            "participant_teamid": teams['team_part_id'],
+            "preregistrantrant_teamid": teams['team_prereg_id']}

--- a/challengeutils/createchallenge.py
+++ b/challengeutils/createchallenge.py
@@ -40,10 +40,12 @@ DREAM_CHALLENGE_TEMPLATE_SYNID = "syn18058986"  # Template 2.0
 
 LIVE_PAGE_MARKDOWN = (
     '## Banner\n\n'
-    '{row}\n {column width=3}\n'
-    '${jointeam?teamId=%s&isChallenge=false&isMemberMessage=You have successfully preregistered for the challenge&text=Click here to preregister&isSimpleRequestButton=true&requestOpenText=Your registration is in progress&successMessage=Your registration is in progress}\n '
-    '{column}\n {column width=9} \n'
-    '###! There are ${teammembercount?teamId=%s} preregistered participants. Join them now!\n '
+    '{row}\n {column width=2}\n '
+    '{column}\n {column width=4}\n'
+    '#### ${jointeam?teamId=%s&isChallenge=false&isMemberMessage=You have successfully preregistered for the challenge&text=Click here to preregister&isSimpleRequestButton=true&requestOpenText=Your registration is in progress&successMessage=Your registration is in progress}\n '
+    '{column}\n {column width=5}\n'
+    '###! There are ${teammembercount?teamId=%s} preregistered participants. <br>**Join them now!**\n '
+    '{column}\n {column width=1}\n '
     '{column}\n{row}\n'
     '\n---\n\n'
     '## Overview\n\n<font size=4>**Goal:**</font>\n\n<font size=4>**Motivation:**</font>\n'

--- a/tests/test_createchallenge.py
+++ b/tests/test_createchallenge.py
@@ -268,10 +268,10 @@ def test_livesitenone_main():
 
 def test_livesite_main():
     """Tests main when live site is not None"""
-    team_map = {'team_part_id': 'syn1234',
-                'team_admin_id': 'syn1234',
-                'team_prereg_id': 'syn1234',
-                'team_org_id': 'syn1234'}
+    team_map = {'team_part_id': '1234',
+                'team_admin_id': '2345',
+                'team_prereg_id': '3456',
+                'team_org_id': '4567'}
     teamid = str(uuid.uuid1())
     project = str(uuid.uuid1())
     chalid = str(uuid.uuid1())
@@ -301,6 +301,13 @@ def test_livesite_main():
          patch.object(createchallenge, "_update_wikipage_string",
                       return_value=wiki),\
          patch.object(SYN, "store"):
-        createchallenge.main(SYN, challenge_name, live_site="syn123")
+        components = createchallenge.main(SYN, challenge_name,
+                                          live_site="syn123")
         assert patch_set_perms.call_count == 2
         assert patch_create_proj.call_count == 1
+        assert components == {"live_projectid": proj.id,
+                              "staging_projectid": proj.id,
+                              "admin_teamid": '2345',
+                              "organizer_teamid": '4567',
+                              "participant_teamid": '1234',
+                              "preregistrantrant_teamid": '3456'}


### PR DESCRIPTION
* #127 

Ideally the fix is to actually improve synapseutils.copyWiki as it is simply too verbose.  That being said, Looks something like this:  `challengeutils createchallenge TestMeNowWork`
```
....
.....
....
TestMeNowWork (Production site): https://www.synapse.org/#!Synapse:syn21963826
TestMeNowWork (Staging site): https://www.synapse.org/#!Synapse:syn21963827
TestMeNowWork (Admin team): https://www.synapse.org/#!Team:3408470
TestMeNowWork (Participant team): https://www.synapse.org/#!Team:3408471
TestMeNowWork (Organizer team): https://www.synapse.org/#!Team:3408469
TestMeNowWork (Pre-registrant team): https://www.synapse.org/#!Team:3408472
```
* #126 
