### PR TITLE
Use github token instead of personal access token

### DIFF
--- a/.github/workflows/sphinx-ghpages.yaml
+++ b/.github/workflows/sphinx-ghpages.yaml
@@ -36,6 +36,6 @@ jobs:
         with:
           branch: gh-pages
           directory: gh-pages
-          github_token: ${{ secrets.ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
       # ===============================


### PR DESCRIPTION
- [ ] Fixes #xxxx (Link the github issue if applicable)
- [x] Did you run your tests locally (instructions [here](https://github.com/Sage-Bionetworks/challengeutils/blob/master/CONTRIBUTING.md))?
- [x] Did you add a good description about your changes or additions?

Currently the github action uses a personal access token.  Every repo actually has a github token which can be used.