### PR TITLE
Get team member count rest call

### DIFF
--- a/challengeutils/teams.py
+++ b/challengeutils/teams.py
@@ -1,24 +1,27 @@
 """Team related functions"""
+from typing import Union
+
+from synapseclient import Synapse, Team
 from synapseclient.core.utils import id_of
 
 
-def _get_team_count(syn, teamid):
-    """Get number of team members
+def _get_team_count(syn: Synapse, teamid: int) -> dict:
+    """Rest call wrapper for getting team member count
 
     Args:
         syn: Synapse object
-        team: Synapse team id
+        teamid: Synapse team id
     """
     count = syn.restGET(f"/teamMembers/count/{teamid}")
     return count
 
 
-def get_team_count(syn, team):
+def get_team_count(syn: Synapse, team: Union[int, str, Team]) -> int:
     """Get number of team members
 
     Args:
         syn: Synapse object
-        team: synaspeclient.Team or its id
+        team: synaspeclient.Team, its id, or name.
     """
     team_obj = syn.getTeam(team)
     count = _get_team_count(syn, team_obj.id)

--- a/challengeutils/teams.py
+++ b/challengeutils/teams.py
@@ -1,0 +1,25 @@
+"""Team related functions"""
+from synapseclient.core.utils import id_of
+
+
+def _get_team_count(syn, teamid):
+    """Get number of team members
+
+    Args:
+        syn: Synapse object
+        team: Synapse team id
+    """
+    count = syn.restGET(f"/teamMembers/count/{teamid}")
+    return count
+
+
+def get_team_count(syn, team):
+    """Get number of team members
+
+    Args:
+        syn: Synapse object
+        team: synaspeclient.Team or its id
+    """
+    team_obj = syn.getTeam(team)
+    count = _get_team_count(syn, team_obj.id)
+    return count['count']

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1,0 +1,35 @@
+"""Testing team module"""
+from unittest import mock
+from unittest.mock import Mock, patch
+
+import synapseclient
+from challengeutils import teams
+
+class TestTeam:
+    """Test team module functions"""
+
+    def setup_method(self):
+        """Method called once per method"""
+        self.syn = mock.create_autospec(synapseclient.Synapse)
+        self.return_count = {"count": 3}
+
+    def test__get_team_count_rest(self):
+        """Test rest call wrapper"""
+        with patch.object(self.syn, "restGET",
+                          return_value=self.return_count) as rest_get:
+            count = teams._get_team_count(self.syn, 2222)
+            rest_get.assert_called_once_with("/teamMembers/count/2222")
+            assert count == self.return_count
+
+    def test_get_team_count(self):
+        """Test getting team count"""
+        fake_team = Mock(id=2222)
+        with patch.object(self.syn, "getTeam",
+                          return_value=fake_team) as get_team,\
+             patch.object(teams, "_get_team_count",
+                          return_value=self.return_count) as get_count:
+            count = teams.get_team_count(self.syn, "team")
+
+            get_team.assert_called_once_with("team")
+            get_count.assert_called_once_with(self.syn, 2222)
+            assert count == self.return_count['count']

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import synapseclient
 from challengeutils import teams
 
+
 class TestTeam:
     """Test team module functions"""
 


### PR DESCRIPTION
- [ ] Fixes #xxxx (Link the github issue if applicable)
- [x] Did you run your tests locally (instructions [here](https://github.com/Sage-Bionetworks/challengeutils/blob/master/CONTRIBUTING.md))?
- [x] Did you add a good description about your changes or additions?

Get number of team members given a team name, id or Team object.