### PR TITLE
fix conditionals for permissions check

### DIFF
--- a/challengeutils/submission.py
+++ b/challengeutils/submission.py
@@ -145,7 +145,7 @@ def _validate_public_permissions(syn, proj):
         syn_users_perms = syn.getPermissions(
             proj.entityId, AUTHENTICATED_USERS)
         public_perms = syn.getPermissions(proj.entityId)
-        if set(syn_users_perms) == {"READ", "DOWNLOAD"} and \
+        if ("READ" in syn_users_perms and "DOWNLOAD" in syn_users_perms) and \
                 "READ" in public_perms:
             error = ""
 
@@ -166,7 +166,7 @@ def _validate_admin_permissions(syn, proj, admin):
     try:
         # Remove error message if admin has read and download permissions.
         admin_perms = syn.getPermissions(proj.entityId, admin)
-        if set(admin_perms) == {"READ", "DOWNLOAD"}:
+        if "READ" in admin_perms and "DOWNLOAD" in admin_perms:
             error = ""
 
     except SynapseHTTPError as e:


### PR DESCRIPTION
- [x] Did you run your tests locally?
- [x] Did you add a good description about your changes or additions?

---

The current issue was that using the set comparison made it so the permissions had to be just `READ` and `DOWNLOAD`.  If someone had additional permissions, e.g. `UPDATE`, validation would fail (even though they would technically have access to the project).