### PR TITLE
`challengeutils` cli command should behave like `challengeutils -h`

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -801,9 +801,14 @@ def synapse_login(synapse_config):
 
 
 def main():
-    args = build_parser().parse_args()
+    parser = build_parser()
+    args = parser.parse_args()
     syn = synapse_login(args.synapse_config)
-    args.func(syn, args)
+    try:
+        args.func(syn, args)
+    except AttributeError:
+        parser.print_help()
+        parser.exit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] Fixes #219 
- [x] Did you run your tests locally (instructions [here](https://github.com/Sage-Bionetworks/challengeutils/blob/master/CONTRIBUTING.md))?
- [x] Did you add a good description about your changes or additions?

Running `challengeutils` should not error out