### PR TITLE
Feature transfer queue

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -786,15 +786,11 @@ def build_parser():
     parser_push_wiki.set_defaults(func=command_push_wiki)
 
     parser_transfer_queue = subparsers.add_parent(
-        "transfer-queue",
-        help="Transfer Evaluation to another Challenge project")
+        "transfer-queue", help="Transfer Evaluation to another Challenge project")
     parser_transfer_queue.add_argument(
-        "eval_id", type=int,
-        help="Evaluation ID (7-digit ID)"
-    )
+        "eval_id", type=int, help="Evaluation ID (7-digit ID)")
     parser_transfer_queue.add_argument(
-        "new_project_id", type=str,
-        help="Destination project ID, e.g. syn12345678")
+        "new_project_id", type=str, help="Destination project ID, e.g. syn12345678")
     parser_transfer_queue.set_defaults(func=command_transfer_queue)
 
     return parser

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -372,6 +372,13 @@ def command_push_wiki(syn, args):
         json.dump(wiki_headers, config, indent=4)
 
 
+def command_transfer_queue(syn, args):
+    print(
+            evaluation_queue.transfer_evaluation(
+            syn, args.eval_id, args.new_project_id)
+    )
+
+
 def build_parser():
     """Builds the argument parser and returns the result."""
     parser = argparse.ArgumentParser(description="Challenge utility functions")
@@ -777,6 +784,17 @@ def build_parser():
         "Defaults to location of where code is being executed.",
     )
     parser_push_wiki.set_defaults(func=command_push_wiki)
+
+    parser_transfer_queue = subparsers.add_parent("transfer-queue",
+                                                  help="Transfer Evaluation to another Challenge project")
+    parser_transfer_queue.add_argument(
+        "eval_id", type=int,
+        help="Evaluation ID (7-digit ID)"
+    )
+    parser_transfer_queue.add_argument(
+        "new_project_id", type=str,
+        help="Destination project ID, e.g. syn12345678")
+    parser_transfer_queue.set_defaults(func=command_transfer_queue)
 
     return parser
 

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -373,10 +373,7 @@ def command_push_wiki(syn, args):
 
 
 def command_transfer_queue(syn, args):
-    print(
-        evaluation_queue.transfer_evaluation(
-            syn, args.eval_id, args.new_project_id)
-    )
+    print(evaluation_queue.transfer_evaluation(syn, args.eval_id, args.new_project_id))
 
 
 def build_parser():
@@ -786,11 +783,14 @@ def build_parser():
     parser_push_wiki.set_defaults(func=command_push_wiki)
 
     parser_transfer_queue = subparsers.add_parent(
-        "transfer-queue", help="Transfer Evaluation to another Challenge project")
+        "transfer-queue", help="Transfer Evaluation to another Challenge project"
+    )
     parser_transfer_queue.add_argument(
-        "eval_id", type=int, help="Evaluation ID (7-digit ID)")
+        "eval_id", type=int, help="Evaluation ID (7-digit ID)"
+    )
     parser_transfer_queue.add_argument(
-        "new_project_id", type=str, help="Destination project ID, e.g. syn12345678")
+        "new_project_id", type=str, help="Destination project ID, e.g. syn12345678"
+    )
     parser_transfer_queue.set_defaults(func=command_transfer_queue)
 
     return parser

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -374,7 +374,7 @@ def command_push_wiki(syn, args):
 
 def command_transfer_queue(syn, args):
     print(
-            evaluation_queue.transfer_evaluation(
+        evaluation_queue.transfer_evaluation(
             syn, args.eval_id, args.new_project_id)
     )
 
@@ -785,8 +785,9 @@ def build_parser():
     )
     parser_push_wiki.set_defaults(func=command_push_wiki)
 
-    parser_transfer_queue = subparsers.add_parent("transfer-queue",
-                                                  help="Transfer Evaluation to another Challenge project")
+    parser_transfer_queue = subparsers.add_parent(
+        "transfer-queue",
+        help="Transfer Evaluation to another Challenge project")
     parser_transfer_queue.add_argument(
         "eval_id", type=int,
         help="Evaluation ID (7-digit ID)"

--- a/challengeutils/evaluation_queue.py
+++ b/challengeutils/evaluation_queue.py
@@ -134,3 +134,11 @@ def set_evaluation_quota(syn: Synapse, evalid: int, **kwargs):
     evaluation.quota = vars(quota)
     evaluation = syn.store(evaluation)
     return evaluation
+
+
+def transfer_evaluation(syn: Synapse, eval_id: int, new_project_id: str):
+    """Transfer Evaluation queue from one Project to another."""
+    evaluation = syn.getEvaluation(eval_id)
+    evaluation.contentSource = new_project_id
+    evaluation = syn.store(evaluation)
+    return evaluation

--- a/docs/client/admin.rst
+++ b/docs/client/admin.rst
@@ -228,6 +228,35 @@ Positional
 
 -------
 
+Transfer an evaluation queue
+-------------------------
+
+Synopsis
+^^^^^^^^
+
+transfer-queue
+    eval_id new_project_id
+
+Description
+^^^^^^^^^^^
+
+Transfers an Evaluation queue from one Challenge project to another.
+
+Positional
+^^^^^^^^^^
+
+.. program:: challengeutils transfer-queue
+
+.. cmdoption:: eval_id
+
+    Evaluation ID on Synapse, e.g. ``9876543``
+
+.. cmdoption:: project_id
+
+    Destination project ID on Synapse, e.g. ``syn12345678``
+
+-------
+
 
 Query an evaluation
 -------------------

--- a/tests/test_evaluation_queue.py
+++ b/tests/test_evaluation_queue.py
@@ -17,19 +17,21 @@ def test_keys__convert_date_to_epoch():
     date_string = "2020-02-21T15:00:00"
     epoch_info = evaluation_queue._convert_date_to_epoch(date_string)
     assert "time_string" in epoch_info and "epochtime_ms" in epoch_info
-    assert epoch_info['time_string'].endswith(".000Z")
-    assert isinstance(epoch_info['epochtime_ms'], int)
+    assert epoch_info["time_string"].endswith(".000Z")
+    assert isinstance(epoch_info["epochtime_ms"], int)
 
 
 def test_raiseerrors_submissionquota():
     """Tests that errors are raised when wrong parameters are passed in"""
-    with pytest.raises(ValueError,
-                       match="Can only specify round_end or round_duration"):
+    with pytest.raises(
+        ValueError, match="Can only specify round_end or round_duration"
+    ):
         evaluation_queue._create_quota(round_end="foo", round_duration="")
 
-    with pytest.raises(ValueError,
-                       match="If round_end is specified, "
-                             "round_start must also be specified"):
+    with pytest.raises(
+        ValueError,
+        match="If round_end is specified, " "round_start must also be specified",
+    ):
         evaluation_queue._create_quota(round_end="foo")
 
 
@@ -39,14 +41,18 @@ def test_calculateduration_submissionquota():
     second = random.randint(300000, 4000000)
     first_time = str(uuid.uuid1())
 
-    with patch.object(evaluation_queue,
-                      "_convert_date_to_epoch",
-                      side_effect=[{"time_string": first_time,
-                                    "epochtime_ms": first},
-                                   {"time_string": "doo",
-                                    "epochtime_ms": second}]):
-        quota = evaluation_queue._create_quota(round_start="2020-02-21T15:00:00",  # noqa pylint: disable=line-too-long
-                                               round_end="2020-02-21T17:00:00")
+    with patch.object(
+        evaluation_queue,
+        "_convert_date_to_epoch",
+        side_effect=[
+            {"time_string": first_time, "epochtime_ms": first},
+            {"time_string": "doo", "epochtime_ms": second},
+        ],
+    ):
+        quota = evaluation_queue._create_quota(
+            round_start="2020-02-21T15:00:00",  # noqa pylint: disable=line-too-long
+            round_end="2020-02-21T17:00:00",
+        )
         assert quota.firstRoundStart == first_time
         assert quota.roundDurationMillis == second - first
 
@@ -57,21 +63,27 @@ def test_negativeduration_submissionquota():
     second = random.randint(0, 200000)
     first_time = str(uuid.uuid1())
 
-    with patch.object(evaluation_queue,
-                      "_convert_date_to_epoch",
-                      side_effect=[{"time_string": first_time,
-                                    "epochtime_ms": first},
-                                   {"time_string": "doo",
-                                    "epochtime_ms": second}]),\
-        pytest.raises(ValueError,
-                      match="Specified round_duration must be >= 0, or "
-                      "round_end must be > round_start"):
-        evaluation_queue._create_quota(round_start="2020-02-21T15:00:00",
-                                       round_end="2020-02-21T17:00:00")
+    with patch.object(
+        evaluation_queue,
+        "_convert_date_to_epoch",
+        side_effect=[
+            {"time_string": first_time, "epochtime_ms": first},
+            {"time_string": "doo", "epochtime_ms": second},
+        ],
+    ), pytest.raises(
+        ValueError,
+        match="Specified round_duration must be >= 0, or "
+        "round_end must be > round_start",
+    ):
+        evaluation_queue._create_quota(
+            round_start="2020-02-21T15:00:00", round_end="2020-02-21T17:00:00"
+        )
 
-    with pytest.raises(ValueError,
-                       match="Specified round_duration must be >= 0, or "
-                             "round_end must be > round_start"):
+    with pytest.raises(
+        ValueError,
+        match="Specified round_duration must be >= 0, or "
+        "round_end must be > round_start",
+    ):
         evaluation_queue._create_quota(round_duration=-2)
 
 
@@ -81,17 +93,23 @@ def test_run_set_evaluation_quota():
     evalid = str(uuid.uuid1())
     name = str(uuid.uuid1())
     test_eval = synapseclient.Evaluation(name=name, contentSource="syn1234")
-    final_eval = synapseclient.Evaluation(name=name, contentSource="syn1234",
-                                          quota={"submissionLimit": sub,
-                                                 "numberOfRounds": None,
-                                                 "roundDurationMillis": None,
-                                                 "firstRoundStart": None})
+    final_eval = synapseclient.Evaluation(
+        name=name,
+        contentSource="syn1234",
+        quota={
+            "submissionLimit": sub,
+            "numberOfRounds": None,
+            "roundDurationMillis": None,
+            "firstRoundStart": None,
+        },
+    )
 
-    with patch.object(SYN, "getEvaluation",
-                      return_value=test_eval) as patch_geteval,\
-            patch.object(SYN, "store", return_value=final_eval) as patch_store:
-        queue = evaluation_queue.set_evaluation_quota(SYN, evalid,
-                                                      submission_limit=sub)
+    with patch.object(
+        SYN, "getEvaluation", return_value=test_eval
+    ) as patch_geteval, patch.object(
+        SYN, "store", return_value=final_eval
+    ) as patch_store:
+        queue = evaluation_queue.set_evaluation_quota(SYN, evalid, submission_limit=sub)
         assert queue == final_eval
         patch_store.assert_called_once_with(final_eval)
         patch_geteval.assert_called_once_with(evalid)

--- a/tests/test_evaluation_queue.py
+++ b/tests/test_evaluation_queue.py
@@ -63,9 +63,9 @@ def test_negativeduration_submissionquota():
                                     "epochtime_ms": first},
                                    {"time_string": "doo",
                                     "epochtime_ms": second}]),\
-         pytest.raises(ValueError,
-                       match="Specified round_duration must be >= 0, or "
-                             "round_end must be > round_start"):
+        pytest.raises(ValueError,
+                      match="Specified round_duration must be >= 0, or "
+                      "round_end must be > round_start"):
         evaluation_queue._create_quota(round_start="2020-02-21T15:00:00",
                                        round_end="2020-02-21T17:00:00")
 
@@ -89,9 +89,20 @@ def test_run_set_evaluation_quota():
 
     with patch.object(SYN, "getEvaluation",
                       return_value=test_eval) as patch_geteval,\
-         patch.object(SYN, "store", return_value=final_eval) as patch_store:
+            patch.object(SYN, "store", return_value=final_eval) as patch_store:
         queue = evaluation_queue.set_evaluation_quota(SYN, evalid,
                                                       submission_limit=sub)
         assert queue == final_eval
         patch_store.assert_called_once_with(final_eval)
         patch_geteval.assert_called_once_with(evalid)
+
+
+def test_transfer_queue():
+    old_project_id = "syn123"
+    new_project_id = "syn456"
+    eval_id = str(uuid.uuid1())
+
+    test_eval = synapseclient.Evaluation(name="test", contentSource=old_project_id)
+    with patch.object(SYN, "getEvaluation", return_value=test_eval) as patch_geteval:
+        evaluation_queue.transfer_evaluation(SYN, eval_id, new_project_id)
+        assert test_eval.contentSource == new_project_id


### PR DESCRIPTION
This PR will add a convenience function to easily transfer an evaluation queue to another.

This will especially be useful when a Challenge is a recurring one (like BraTS).
