### PR TITLE
Update cmd name in setup config

### DIFF
--- a/challengeutils/submission.py
+++ b/challengeutils/submission.py
@@ -180,7 +180,6 @@ def _validate_public_permissions(syn, proj):
             error = ""
 
     except SynapseHTTPError as e:
-
         # Raise exception message if error is not a permissions error.
         if e.response.status_code != 403:
             raise e
@@ -202,7 +201,6 @@ def _validate_admin_permissions(syn, proj, admin):
             error = ""
 
     except SynapseHTTPError as e:
-
         # Raise exception message if error is not a permissions error.
         if e.response.status_code != 403:
             raise e

--- a/challengeutils/synapseservices/challenge.py
+++ b/challengeutils/synapseservices/challenge.py
@@ -23,7 +23,6 @@ class Challenge(Service):
         etag: str = None,
         participantTeamId: str = None,
     ):
-
         self.openapi_types = {
             "id": str,
             "projectId": str,

--- a/challengeutils/synapseservices/discussion.py
+++ b/challengeutils/synapseservices/discussion.py
@@ -3,7 +3,6 @@ from .base_service import Service, deserialize_model
 
 class Forum(Service):
     def __init__(self, id=None, projectId=None, etag=None):
-
         self.openapi_types = {"id": str, "projectid": str, "etag": str}
 
         self.attribute_map = {"id": "id", "projectid": "projectId", "etag": "etag"}
@@ -70,7 +69,6 @@ class Thread(Service):
         isDeleted: bool = False,
         isPinned: bool = False,
     ):
-
         self.openapi_types = {
             "id": str,
             "forumid": str,
@@ -296,7 +294,6 @@ class Reply(Service):
         isEdited: bool = False,
         isDeleted: bool = False,
     ):
-
         self.openapi_types = {
             "id": str,
             "threadid": str,

--- a/challengeutils/utils.py
+++ b/challengeutils/utils.py
@@ -18,6 +18,7 @@ from synapseclient.core.utils import id_of
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 # TODO: Deprecate once fully using submissionviews
 def _switch_annotation_permission(add_annotations, existing_annotations, force=False):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ scripts =
 
 [options.entry_points]
 console_scripts =
-    geniesp = challengeutils.__main__:main
+    challengeutils = challengeutils.__main__:main
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
## Bug

When building the package, the CLI name is `geniesp` rather than `challengeutils`:

```
$ geniesp -v
challengeutils 4.1.0
```

## Proposed fix

Update the setup config to use `challengeutils` instead of `geniesp`:

```
$ challengeutils -v
challengeutils 4.1.0
```
