### PR TITLE
Update requirements file for dev env

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .
-synapseclient==2.0.0
+synapseclient==2.7.0
 pandas
 pytest
 sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ pytest
 sphinx_rtd_theme
 Sphinx
 black
+jellyfish
+tabulate
+scipy


### PR DESCRIPTION
## Bug

When doing local development, the following libraries/packages are missing from the requirements file:

* jellyfish
* tabulate
* scipy

## Proposed fix

Add missing libraries/packages to `requirements-dev.txt`.  Also update `synapseclient` version to the latest stable version (2.7.0).