### PR TITLE
feat: add portal challenge

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -468,7 +468,8 @@ def build_parser():
     parser_createchallenge.set_defaults(func=command_createchallenge)
 
     parser_create_portal_challenge = subparsers.add_parser(
-        "create-portal-challenge", help="Create a Sage Challenge Portal challenge from template"
+        "create-portal-challenge",
+        help="Create a Sage Challenge Portal challenge from template"
     )
     parser_create_portal_challenge.add_argument("challenge_name", help="Challenge name")
     parser_create_portal_challenge.add_argument(

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -88,7 +88,7 @@ def command_create_portal_challenge(syn, args):
     >>> challengeutils create-portal-challenge "Challenge Name Here" [-n <int>]
     """
     challenge_components = create_portal_challenge.main(
-        syn, args.challengename, args.tasks_count, args.livesiteid
+        syn, args.challenge_name, args.tasks_count, args.livesiteid
     )
     # component: project or team
     # componentid: project id or teamid
@@ -474,7 +474,7 @@ def build_parser():
     parser_create_portal_challenge.add_argument(
         "-n",
         "--tasks_count",
-        default=1,
+        type=int, default=1,
         help=(
             "Number of challenge tasks (default: 1)"
         ),

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -470,8 +470,8 @@ def build_parser():
     parser_create_portal_challenge = subparsers.add_parser(
         "create-portal-challenge", help="Create a Sage Challenge Portal challenge from template"
     )
-    parser_createchallenge.add_argument("challenge_name", help="Challenge name")
-    parser_createchallenge.add_argument(
+    parser_create_portal_challenge.add_argument("challenge_name", help="Challenge name")
+    parser_create_portal_challenge.add_argument(
         "-n",
         "--tasks_count",
         default=1,
@@ -479,13 +479,13 @@ def build_parser():
             "Number of challenge tasks (default: 1)"
         ),
     )
-    parser_createchallenge.add_argument(
+    parser_creparser_create_portal_challengeatechallenge.add_argument(
         "--livesiteid",
         help=(
             "Option to specify the live site synapse Id" " there is already a live site"
         ),
     )
-    parser_createchallenge.set_defaults(func=command_create_portal_challenge)
+    parser_create_portal_challenge.set_defaults(func=command_create_portal_challenge)
 
     parser_mirrorwiki = subparsers.add_parser(
         "mirror-wiki",

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -98,7 +98,7 @@ def command_create_portal_challenge(syn, args):
             urls[component] = f"https://www.synapse.org/#!Synapse:{componentid}"
         elif component.endswith("teamid"):
             urls[component] = f"https://www.synapse.org/#!Team:{componentid}"
-    urls["name"] = args.challengename
+    urls["name"] = args.challenge_name
     text = (
         "{name} (Production site): {live_projectid}",
         "{name} (Staging site): {staging_projectid}",
@@ -472,7 +472,7 @@ def build_parser():
     )
     parser_create_portal_challenge.add_argument("challenge_name", help="Challenge name")
     parser_create_portal_challenge.add_argument(
-        "-n",
+        "-t",
         "--tasks_count",
         type=int, default=1,
         help=(

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -479,7 +479,7 @@ def build_parser():
             "Number of challenge tasks (default: 1)"
         ),
     )
-    parser_creparser_create_portal_challengeatechallenge.add_argument(
+    parser_create_portal_challenge.add_argument(
         "--livesiteid",
         help=(
             "Option to specify the live site synapse Id" " there is already a live site"

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -16,6 +16,7 @@ from synapseclient.core.exceptions import (
 from . import (
     annotations,
     createchallenge,
+    create_portal_challenge,
     challenge,
     cheat_detection,
     evaluation_queue,
@@ -76,6 +77,33 @@ def command_createchallenge(syn, args):
         "{name} (Participant team): {organizer_teamid}",
         "{name} (Organizer team): {participant_teamid}",
         "{name} (Pre-registrant team): {preregistrantrant_teamid}",
+    )
+    print("\n" + "\n".join(text).format(**urls))
+    return challenge_components
+
+
+def command_create_portal_challenge(syn, args):
+    """Creates a challenge on the Sage Challenge Portal.
+
+    >>> challengeutils create-portal-challenge "Challenge Name Here" [-n <int>]
+    """
+    challenge_components = create_portal_challenge.main(
+        syn, args.challengename, args.tasks_count, args.livesiteid
+    )
+    # component: project or team
+    # componentid: project id or teamid
+    urls = {}
+    for component, componentid in challenge_components.items():
+        if component.endswith("projectid"):
+            urls[component] = f"https://www.synapse.org/#!Synapse:{componentid}"
+        elif component.endswith("teamid"):
+            urls[component] = f"https://www.synapse.org/#!Team:{componentid}"
+    urls["name"] = args.challengename
+    text = (
+        "{name} (Production site): {live_projectid}",
+        "{name} (Staging site): {staging_projectid}",
+        "{name} (Participant team): {organizer_teamid}",
+        "{name} (Organizer team): {participant_teamid}",
     )
     print("\n" + "\n".join(text).format(**urls))
     return challenge_components
@@ -438,6 +466,26 @@ def build_parser():
         ),
     )
     parser_createchallenge.set_defaults(func=command_createchallenge)
+
+    parser_create_portal_challenge = subparsers.add_parser(
+        "create-portal-challenge", help="Create a Sage Challenge Portal challenge from template"
+    )
+    parser_createchallenge.add_argument("challenge_name", help="Challenge name")
+    parser_createchallenge.add_argument(
+        "-n",
+        "--tasks_count",
+        default=1,
+        help=(
+            "Number of challenge tasks (default: 1)"
+        ),
+    )
+    parser_createchallenge.add_argument(
+        "--livesiteid",
+        help=(
+            "Option to specify the live site synapse Id" " there is already a live site"
+        ),
+    )
+    parser_createchallenge.set_defaults(func=command_create_portal_challenge)
 
     parser_mirrorwiki = subparsers.add_parser(
         "mirror-wiki",

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -235,7 +235,7 @@ def create_organizer_tables(syn, project_id):
     # FIXME: for some reason, storing the table will then call on the
     #        `challengeutils` CLI again
     table = syn.store(table)
-    logger.info(f" Table created: {table.name} ({table.id}) ✔")
+    logger.info(f"    Table created: {table.name} ({table.id}) ✔")
 
     # FIXME: due to the issue above, we are not able to create the
     #        MaterializedViews
@@ -248,7 +248,7 @@ def create_organizer_tables(syn, project_id):
         )
         view = syn.store(view)
         view_ids[role_title] = view.id
-        logger.info(f" MaterializedView created: {view.name} ({view.id}) ✔")
+        logger.info(f"    MaterializedView created: {view.name} ({view.id}) ✔")
     return view_ids
 
 
@@ -270,7 +270,7 @@ def create_data_folders(syn, project_id, tasks_count):
         )
         folder = syn.store(folder)
         folder_ids[i] = folder.id
-        logger.info(f" Folder created: {folder.name} ({folder.id}) ✔")
+        logger.info(f"    Folder created: {folder.name} ({folder.id}) ✔")
     return folder_ids
 
 
@@ -296,7 +296,7 @@ def create_annotations(syn, project_id, table_ids, folder_ids):
     for i, synid in folder_ids.items():
         project[f'Task_{i + 1}.DataFolder'] = synid
     project = syn.store(project)
-    logger.info(" Annotations creation complete.")
+    logger.info("    Annotations creation complete ✔")
     return project
 
 

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -255,7 +255,7 @@ def create_organizer_tables(syn, project_id):
 
 def create_data_folders(syn, project_id, tasks_count):
     """Create folders for challenge data, one for each task.
-    
+
     Args:
         syn: Synapse object
         parent_id: project synID
@@ -345,7 +345,8 @@ def main(syn, challenge_name, tasks_count, live_site=None):
             f"Task {i + 1} Submission",
             project_live.id,
         )
-    # TODO: the following function does not work for some reason; see function for details
+    # TODO: the following function does not work for some reason; see function
+    #       for details
     # tables = create_organizer_tables(syn, project_live.id)
     tables = {}
 

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -325,6 +325,22 @@ def main(syn, challenge_name, tasks_count, live_site=None):
         project_live = syn.get(live_site)
 
     challenge_obj = create_challenge_widget(syn, project_live, teams["team_part_id"])
+    # TODO: the following function does not work for some reason; see function for details
+    # tables = create_organizer_tables(syn, project_live.id)
+    tables = {}
+
+    # Create data folder(s) and set their local sharing settings as:
+    #     - organizers team = download access
+    #     - participants team = download access
+    folders = create_data_folders(syn, project_live.id, tasks_count)
+    for _, folder_id in folders.items():
+        permissions.set_entity_permissions(
+            syn, folder_id, teams["team_org_id"], permission_level="download"
+        )
+        permissions.set_entity_permissions(
+            syn, folder_id, teams["team_part_id"], permission_level="download"
+        )
+
     # Add the basic annotations to the live Project - some can be pre-filled but the
     # majority will need to filled out on the web UI.
     project_live = create_annotations(syn, project_live.id, tables, folders)

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -20,14 +20,14 @@ import synapseclient
 from synapseclient.core.exceptions import SynapseHTTPError
 import synapseutils
 
-from . import challenge, permissions, utils
+from . import challenge, permissions
 
 logger = logging.getLogger(__name__)
 
 CHALLENGE_TEMPLATE_SYNID = "syn52941681"
-TASK_WIKI_ID = "624554"
 TABLE_TEMPLATE_SYNID = "syn52955244"
 CHALLENGE_ROLES = ['organizer', 'contributor', 'sponsor']
+TASK_WIKI_ID = "624554"
 
 
 def create_project(syn, project_name):

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -224,6 +224,7 @@ def create_organizer_tables(syn, project_id):
         syn: Synapse object
         parent_id: project synID
     """
+    logger.info(" Creating tables...")
     view_ids = {}
     schema = synapseclient.Schema(
         name='Organizing Team',
@@ -234,7 +235,7 @@ def create_organizer_tables(syn, project_id):
     # FIXME: for some reason, storing the table will then call on the
     #        `challengeutils` CLI again
     table = syn.store(table)
-    logger.info(f" Table created: {table.name} ({table.id})")
+    logger.info(f" Table created: {table.name} ({table.id}) ✔")
 
     # FIXME: due to the issue above, we are not able to create the
     #        MaterializedViews
@@ -247,7 +248,7 @@ def create_organizer_tables(syn, project_id):
         )
         view = syn.store(view)
         view_ids[role_title] = view.id
-        logger.info(f" MaterializedView created: {view.name} ({view.id})")
+        logger.info(f" MaterializedView created: {view.name} ({view.id}) ✔")
     return view_ids
 
 
@@ -259,6 +260,7 @@ def create_data_folders(syn, project_id, tasks_count):
         parent_id: project synID
         tasks_count: Number of task folders to create        
     """
+    logger.info(" Creating folders...")
     folder_ids = {}
     for i in range(0, tasks_count):
         folder_name = f"Task {i + 1}"
@@ -268,7 +270,7 @@ def create_data_folders(syn, project_id, tasks_count):
         )
         folder = syn.store(folder)
         folder_ids[i] = folder.id
-        logger.info(f"Folder created: {folder.name} ({folder.id})")
+        logger.info(f" Folder created: {folder.name} ({folder.id}) ✔")
     return folder_ids
 
 
@@ -293,7 +295,6 @@ def create_annotations(syn, project_id, table_ids, folder_ids):
     # #     annots[role] = synid
     for i, synid in folder_ids.items():
         project[f'Task_{i + 1}.DataFolder'] = synid
-    print(project)
     project = syn.store(project)
     logger.info(" Annotations creation complete.")
     return project

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -1,0 +1,218 @@
+"""Create challenge on the Sage Challenge Portal.
+
+Feature to create a new challenge based on a template. The new challenge
+will include tw Synapse projects (one for dev, one for prod), two teams
+(Participants and Organizers), one table to list organizers, and an
+evaluation queue.
+
+Example::
+
+    import challengeutils
+    import synapseclient
+    syn = synapseclient.login()
+    challengeutils.create_portal_challenge.main(syn, "Foo Challenge")
+
+"""
+import logging
+import sys
+
+import synapseclient
+from synapseclient.core.exceptions import SynapseHTTPError
+import synapseutils
+
+from . import challenge, permissions, utils
+
+logger = logging.getLogger(__name__)
+
+CHALLENGE_TEMPLATE_SYNID = "syn52941681"
+TASK_WIKI_ID = "624554"
+TABLE_TEMPLATE_SYNID = "syn52955244"
+CHALLENGE_ROLES = ['organizer', 'contributor', 'sponsor']
+
+
+def create_project(syn, project_name):
+    """Creates Synapse Project
+
+    Args:
+        syn: Synpase object
+        project_name: Name of project
+
+    Returns:
+        Project Entity
+    """
+    project = synapseclient.Project(project_name)
+    project = syn.store(project)
+    logger.info("Created Project {} ({})".format(project.name, project.id))
+    return project
+
+
+
+def create_evaluation_queue(syn, name, description, parentid):
+    """
+    Creates Evaluation Queues
+
+    Args:
+        syn: Synpase object
+        name: Name of evaluation queue
+        description: Description of queue
+        parentid: Synapse project id
+
+    Returns:
+        Evalation Queue
+    """
+    queue_ent = synapseclient.Evaluation(
+        name=name, description=description, contentSource=parentid
+    )
+    queue = syn.store(queue_ent)
+    logger.info("Created Queue {}({})".format(queue.name, queue.id))
+    return queue
+
+
+def create_challenge_widget(syn, project_live, team_part_id):
+    """Creates challenge widget - activates a Synapse project
+    If challenge object exists, it retrieves existing object
+
+    Args:
+        syn: Synpase object
+        project_live: Synapse id of live challenge project
+        team_part_id: Synapse team id of participant team
+    """
+    try:
+        chal_obj = challenge.create_challenge(syn, project_live, team_part_id)
+        logger.info("Created Challenge ({})".format(chal_obj.id))
+    except SynapseHTTPError:
+        chal_obj = challenge.get_challenge(syn, project_live)
+        logger.info("Fetched existing Challenge ({})".format(chal_obj.id))
+    return chal_obj
+
+
+def _update_wikipage_string(
+    wikipage_string, challengeid, teamid, challenge_name, synid
+):
+    """Updates wikipage strings in the challenge wiki template
+    with the newly created challengeid, teamid, challenge name and project id
+
+    Args:
+        wikipage_string: Original wikipage string
+        challengeid: New challenge id
+        teamid: Synapse Team id
+        challenge_name: challenge name
+        synid: Synapse id of project
+
+    Returns:
+        fixed wiki page string
+    """
+    wikipage_string = wikipage_string.replace(
+        "challengeId=0", "challengeId=%s" % challengeid
+    )
+    wikipage_string = wikipage_string.replace("{teamId}", teamid)
+    wikipage_string = wikipage_string.replace("teamId=0", "teamId=%s" % teamid)
+    wikipage_string = wikipage_string.replace("#!Map:0", "#!Map:%s" % teamid)
+    wikipage_string = wikipage_string.replace("{challengeName}", challenge_name)
+    wikipage_string = wikipage_string.replace("projectId=syn0", "projectId=%s" % synid)
+    return wikipage_string
+
+
+def check_existing_and_delete_wiki(syn, synid):
+    """Checks if wiki exists, and if so prompt to delete
+
+    Args:
+        syn: Synapse connection
+        synid: Synapse id of an Entity
+    """
+    wiki = None
+    try:
+        wiki = syn.getWiki(synid)
+    except SynapseHTTPError:
+        pass
+
+    if wiki is not None:
+        logger.info("The staging project has already a wiki.")
+        logger.info(wiki)
+        user_input = (
+            input("Do you agree to delete the wiki before continuing? (y/N) ") or "n"
+        )
+        if user_input.lower() not in ("y", "yes"):
+            logger.info("Exiting")
+            sys.exit(1)
+        else:
+            logger.info("Deleting wiki of the staging project ({})".format(wiki.id))
+            syn.delete(wiki)
+
+
+def main(syn, challenge_name, tasks_count, live_site=None):
+    """Creates two project entity for challenge sites.
+    1) live (public) and 2) staging (private until launch)
+    Allow for users to set up the live site themselves
+
+    Args:
+        syn: Synapse object
+        challenge_name: Name of the challenge
+        live_site: If there is already a live site, specify live site Synapse
+                   id. (Default is None)
+        tasks_count: number of challenge tasks (default: 1)
+
+    Returns:
+        dict::
+
+            {
+                "live_projectid": projectid,
+                "staging_projectid": projectid,
+                "organizer_teamid": teams['team_org_id'],
+                "participant_teamid": teams['team_part_id']
+            }
+
+    """
+    # Create teams for challenge sites
+    teams = _create_teams(syn, challenge_name)
+
+    # Create live Project
+    if live_site is None:
+        project_live = create_project(syn, challenge_name)
+        permissions.set_entity_permissions(
+            syn, project_live, teams["team_org_id"], permission_level="moderate"
+        )
+        _create_live_wiki(syn, project_live)
+    else:
+        project_live = syn.get(live_site)
+
+    challenge_obj = create_challenge_widget(syn, project_live, teams["team_part_id"])
+    create_evaluation_queue(
+        syn,
+        "%s Project Submission" % challenge_name,
+        "Project Submission",
+        project_live.id,
+    )
+    create_organizer_tables(syn, project_live.id)
+    create_data_folders(syn, project_live.id, tasks_count)
+
+    # Create staging Project
+    project_staging = create_project(syn, challenge_name + " - staging")
+    permissions.set_entity_permissions(
+        syn, project_staging, teams["team_org_id"], permission_level="edit"
+    )
+    # Checks if staging wiki exists, if so delete
+    check_existing_and_delete_wiki(syn, project_staging.id)
+
+    logger.info("Copying wiki template to {}".format(project_staging.name))
+    new_wikiids = synapseutils.copyWiki(
+        syn, CHALLENGE_TEMPLATE_SYNID, project_staging.id
+    )
+    for page in new_wikiids:
+        wikipage = syn.getWiki(project_staging, page["id"])
+        wikipage.markdown = _update_wikipage_string(
+            wikipage.markdown,
+            challenge_obj.id,
+            teams["team_part_id"],
+            challenge_name,
+            project_live.id,
+        )
+        syn.store(wikipage)
+    return {
+        "live_projectid": project_live.id,
+        "staging_projectid": project_staging.id,
+        "admin_teamid": teams["team_admin_id"],
+        "organizer_teamid": teams["team_org_id"],
+        "participant_teamid": teams["team_part_id"],
+        "preregistrantrant_teamid": teams["team_prereg_id"],
+    }

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -259,7 +259,7 @@ def create_data_folders(syn, project_id, tasks_count):
     Args:
         syn: Synapse object
         parent_id: project synID
-        tasks_count: Number of task folders to create        
+        tasks_count: Number of task folders to create
     """
     logger.info(" Creating folders...")
     folder_ids = {}

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -42,7 +42,7 @@ def create_project(syn, project_name):
     """
     project = synapseclient.Project(project_name)
     project = syn.store(project)
-    logger.info(f"Project created: {project.name} ({project.id})")
+    logger.info(f" Project created: {project.name} ({project.id})")
     return project
 
 
@@ -62,12 +62,12 @@ def create_team(syn, team_name, desc, can_public_join=False):
     try:
         # raises a ValueError if a team does not exist
         team = syn.getTeam(team_name)
-        logger.info(f"Team {team_name} already exists.")
+        logger.info(f" Team {team_name} already exists.")
         logger.info(team)
         # If you press enter, this will default to 'y'
         user_input = input("Do you want to use this team? (Y/n) ") or "y"
         if user_input.lower() not in ("y", "yes"):
-            logger.info("Please specify a new challenge name. Exiting.")
+            logger.info(" Please specify a new challenge name. Exiting.")
             sys.exit(1)
     except ValueError:
         team = synapseclient.Team(
@@ -75,7 +75,7 @@ def create_team(syn, team_name, desc, can_public_join=False):
         )
         # raises a ValueError if a team with this name already exists
         team = syn.store(team)
-        logger.info(f"Team created: {team.name} ({team.id})")
+        logger.info(f" Team created: {team.name} ({team.id})")
     return team
 
 
@@ -96,7 +96,7 @@ def create_evaluation_queue(syn, name, description, parentid):
         name=name, description=description, contentSource=parentid
     )
     queue = syn.store(queue_ent)
-    logger.info(f"Queue created: {queue.name} ({queue.id})")
+    logger.info(f" Queue created: {queue.name} ({queue.id})")
     return queue
 
 
@@ -129,10 +129,10 @@ def create_challenge_widget(syn, project_live, team_part_id):
     """
     try:
         chal_obj = challenge.create_challenge(syn, project_live, team_part_id)
-        logger.info(f"Acivated as Challenge ({chal_obj.id})")
+        logger.info(f" Acivated as Challenge (ID: {chal_obj.id})")
     except SynapseHTTPError:
         chal_obj = challenge.get_challenge(syn, project_live)
-        logger.info(f"Fetched existing Challenge ({chal_obj.id})")
+        logger.info(f" Fetched existing Challenge (ID: {chal_obj.id})")
     return chal_obj
 
 
@@ -203,16 +203,16 @@ def check_existing_and_delete_wiki(syn, synid):
         pass
 
     if wiki is not None:
-        logger.info("The staging project has already a wiki.")
+        logger.info(" The staging project has already a wiki.")
         logger.info(wiki)
         user_input = (
             input("Do you agree to delete the wiki before continuing? (y/N) ") or "n"
         )
         if user_input.lower() not in ("y", "yes"):
-            logger.info("Exiting")
+            logger.info(" --- Exiting ---")
             sys.exit(1)
         else:
-            logger.info(f"Deleting wiki of the staging project ({wiki.id})")
+            logger.info(f" Deleting wiki of the staging project ({wiki.id})")
             syn.delete(wiki)
 
 
@@ -234,7 +234,7 @@ def create_organizer_tables(syn, project_id):
     # FIXME: for some reason, storing the table will then call on the
     #        `challengeutils` CLI again
     table = syn.store(table)
-    logger.info(f"Table created: {table.name} ({table.id})")
+    logger.info(f" Table created: {table.name} ({table.id})")
 
     # FIXME: due to the issue above, we are not able to create the
     #        MaterializedViews
@@ -247,7 +247,7 @@ def create_organizer_tables(syn, project_id):
         )
         view = syn.store(view)
         view_ids[role_title] = view.id
-        logger.info(f"MaterializedView created: {view.name} ({view.id})")
+        logger.info(f" MaterializedView created: {view.name} ({view.id})")
     return view_ids
 
 
@@ -274,7 +274,7 @@ def create_data_folders(syn, project_id, tasks_count):
 
 def create_annotations(syn, project_id, table_ids, folder_ids):
     """Create annotations that will power the portal."""
-    logger.info("Creating basic annotations...")
+    logger.info(" Creating basic annotations...")
     project = syn.get(project_id)
 
     # Set basic annotations to the project.
@@ -288,13 +288,14 @@ def create_annotations(syn, project_id, table_ids, folder_ids):
         if not wiki.get('parentId')
     ][0]
     project['Overview'] = f"{project_id}/wiki/{main_wiki_id}"
+    project['Abstract'] = "More challenge information coming soon!"
     # # for role, synid in table_ids.items():
     # #     annots[role] = synid
     for i, synid in folder_ids.items():
         project[f'Task_{i + 1}.DataFolder'] = synid
     print(project)
     project = syn.store(project)
-    logger.info("Annotations creation complete.")
+    logger.info(" Annotations creation complete.")
     return project
 
 
@@ -370,7 +371,7 @@ def main(syn, challenge_name, tasks_count, live_site=None):
     # Checks if staging wiki exists, if so delete
     check_existing_and_delete_wiki(syn, project_staging.id)
 
-    logger.info(f"Copying wiki template to {project_staging.name}")
+    logger.info(f" Copying wiki template to {project_staging.name}")
     new_wikiids = synapseutils.copyWiki(
         syn, CHALLENGE_TEMPLATE_SYNID, project_staging.id
     )

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -42,7 +42,7 @@ def create_project(syn, project_name):
     """
     project = synapseclient.Project(project_name)
     project = syn.store(project)
-    logger.info("Created Project {} ({})".format(project.name, project.id))
+    logger.info(f"Project created: {project.name} ({project.id})")
     return project
 
 
@@ -62,7 +62,7 @@ def create_team(syn, team_name, desc, can_public_join=False):
     try:
         # raises a ValueError if a team does not exist
         team = syn.getTeam(team_name)
-        logger.info("The team {} already exists.".format(team_name))
+        logger.info(f"Team {team_name} already exists.")
         logger.info(team)
         # If you press enter, this will default to 'y'
         user_input = input("Do you want to use this team? (Y/n) ") or "y"
@@ -75,7 +75,7 @@ def create_team(syn, team_name, desc, can_public_join=False):
         )
         # raises a ValueError if a team with this name already exists
         team = syn.store(team)
-        logger.info("Created Team {} ({})".format(team.name, team.id))
+        logger.info(f"Team created: {team.name} ({team.id})")
     return team
 
 
@@ -96,7 +96,7 @@ def create_evaluation_queue(syn, name, description, parentid):
         name=name, description=description, contentSource=parentid
     )
     queue = syn.store(queue_ent)
-    logger.info("Created Queue {}({})".format(queue.name, queue.id))
+    logger.info(f"Queue created: {queue.name} ({queue.id})")
     return queue
 
 
@@ -129,10 +129,10 @@ def create_challenge_widget(syn, project_live, team_part_id):
     """
     try:
         chal_obj = challenge.create_challenge(syn, project_live, team_part_id)
-        logger.info("Created Challenge ({})".format(chal_obj.id))
+        logger.info(f"Acivated as Challenge ({chal_obj.id})")
     except SynapseHTTPError:
         chal_obj = challenge.get_challenge(syn, project_live)
-        logger.info("Fetched existing Challenge ({})".format(chal_obj.id))
+        logger.info(f"Fetched existing Challenge ({chal_obj.id})")
     return chal_obj
 
 
@@ -212,7 +212,7 @@ def check_existing_and_delete_wiki(syn, synid):
             logger.info("Exiting")
             sys.exit(1)
         else:
-            logger.info("Deleting wiki of the staging project ({})".format(wiki.id))
+            logger.info(f"Deleting wiki of the staging project ({wiki.id})")
             syn.delete(wiki)
 
 
@@ -249,6 +249,9 @@ def create_organizer_tables(syn, project_id):
         view_ids[role_title] = view.id
         logger.info(f"MaterializedView created: {view.name} ({view.id})")
     return view_ids
+
+
+def create_data_folders(syn, project_id, tasks_count):
     """Create folders for challenge data, one for each task.
     
     Args:
@@ -256,12 +259,19 @@ def create_organizer_tables(syn, project_id):
         parent_id: project synID
         tasks_count: Number of task folders to create        
     """
+    folder_ids = {}
     for i in range(0, tasks_count):
+        folder_name = f"Task {i + 1}"
         folder = synapseclient.Folder(
-            name=f"Task {i + 1}",
-            parent=parent_id
+            name=folder_name,
+            parent=project_id
         )
         folder = syn.store(folder)
+        folder_ids[i] = folder.id
+        logger.info(f"Folder created: {folder.name} ({folder.id})")
+    return folder_ids
+
+
 def create_annotations(syn, project_id, table_ids, folder_ids):
     """Create annotations that will power the portal."""
     logger.info("Creating basic annotations...")
@@ -360,7 +370,7 @@ def main(syn, challenge_name, tasks_count, live_site=None):
     # Checks if staging wiki exists, if so delete
     check_existing_and_delete_wiki(syn, project_staging.id)
 
-    logger.info("Copying wiki template to {}".format(project_staging.name))
+    logger.info(f"Copying wiki template to {project_staging.name}")
     new_wikiids = synapseutils.copyWiki(
         syn, CHALLENGE_TEMPLATE_SYNID, project_staging.id
     )

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -99,6 +99,30 @@ def create_evaluation_queue(syn, name, description, parentid):
     logger.info("Created Queue {}({})".format(queue.name, queue.id))
     return queue
 
+
+def create_organizer_tables(syn, parent_id):
+    """Create main table of organizers and associating views.
+
+    Args:
+        syn: Synapse object
+        parent_id: project synID
+    """
+    schema = synapseclient.Schema(
+        name='Organizing Team',
+        columns=syn.getColumns(TABLE_TEMPLATE_SYNID),
+        parent=parent_id)
+    table = synapseclient.Table(schema, [[]])
+    table = syn.store(table)
+
+    for role in CHALLENGE_ROLES:
+        view = synapseclient.MaterializedViewSchema(
+            name=role.title() + 's',
+            parent=parent_id,
+            definingSQL=f"SELECT * FROM {table.id} WHERE challengeRole HAS ('{role}')"
+        )
+        syn.store(view)
+
+
 def _create_live_wiki(syn, project):
     """Creates the wiki of the live challenge page
 

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -133,14 +133,13 @@ def _create_live_wiki(syn, project):
         project: Synapse project
         teamid: Synapse team id of participant team
     """
-    markdown = (
-        syn
-        .getWiki(CHALLENGE_TEMPLATE_SYNID)
-        .get('markdown')
-        .replace(
-            "#!Synapse:syn52941681/tables/", 
-            f"#!Synapse:{project.id}/tables/")
-    )
+    markdown = """
+<div align="center" class="alert alert-info">
+
+###! More information coming soon!
+
+</div>
+    """
     syn.store(synapseclient.Wiki(title="", owner=project, markdown=markdown))
 
 

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -327,11 +327,28 @@ def main(syn, challenge_name, tasks_count, live_site=None):
             project_live.id,
         )
         syn.store(wikipage)
+
+    # Create another Task tab per task.
+    for i in range(1, tasks_count):
+        new_tab = synapseclient.Wiki(
+            title=f"Task {i + 1}",
+            owner=project_staging.id,
+            markdown="",
+            parentWikiId=syn.getWiki(project_staging.id).id
+        )
+        new_tab = syn.store(new_tab)
+        synapseutils.copyWiki(
+            syn,
+            CHALLENGE_TEMPLATE_SYNID,
+            project_staging.id,
+            entitySubPageId=TASK_WIKI_ID,
+            destinationSubPageId=new_tab.id,
+            entityMap={CHALLENGE_TEMPLATE_SYNID: project_staging.id}
+        )
+
     return {
         "live_projectid": project_live.id,
         "staging_projectid": project_staging.id,
-        "admin_teamid": teams["team_admin_id"],
         "organizer_teamid": teams["team_org_id"],
         "participant_teamid": teams["team_part_id"],
-        "preregistrantrant_teamid": teams["team_prereg_id"],
     }

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -24,6 +24,7 @@ from . import challenge, permissions
 
 logger = logging.getLogger(__name__)
 
+PORTAL_TABLE = "syn51476218"
 CHALLENGE_TEMPLATE_SYNID = "syn52941681"
 TABLE_TEMPLATE_SYNID = "syn52955244"
 CHALLENGE_ROLES = ['organizer', 'contributor', 'sponsor']
@@ -409,6 +410,12 @@ def main(syn, challenge_name, tasks_count, live_site=None):
                 parentWikiId=new_task_tab.id
             )
             syn.store(task_subwiki)
+
+    # Add project to portal table.
+    project_view = syn.get(PORTAL_TABLE)
+    project_view.scopeIds.append(project_live.id)
+    syn.store(project_view)
+    logger.info(f" Challenge added to 'Curated Challenge Projects' ({PORTAL_TABLE})")
 
     return {
         "live_projectid": project_live.id,

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -67,6 +67,24 @@ def create_evaluation_queue(syn, name, description, parentid):
     logger.info("Created Queue {}({})".format(queue.name, queue.id))
     return queue
 
+def _create_live_wiki(syn, project):
+    """Creates the wiki of the live challenge page
+
+    Args:
+        syn: Synpase object
+        project: Synapse project
+        teamid: Synapse team id of participant team
+    """
+    markdown = (
+        syn
+        .getWiki(CHALLENGE_TEMPLATE_SYNID)
+        .get('markdown')
+        .replace(
+            "#!Synapse:syn52941681/tables/", 
+            f"#!Synapse:{project.id}/tables/")
+    )
+    syn.store(synapseclient.Wiki(title="", owner=project, markdown=markdown))
+
 
 def create_challenge_widget(syn, project_live, team_part_id):
     """Creates challenge widget - activates a Synapse project

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -325,6 +325,13 @@ def main(syn, challenge_name, tasks_count, live_site=None):
         project_live = syn.get(live_site)
 
     challenge_obj = create_challenge_widget(syn, project_live, teams["team_part_id"])
+    for i in range(0, tasks_count):
+        create_evaluation_queue(
+            syn,
+            f"{challenge_name} Task {i + 1}",
+            f"Task {i + 1} Submission",
+            project_live.id,
+        )
     # TODO: the following function does not work for some reason; see function for details
     # tables = create_organizer_tables(syn, project_live.id)
     tables = {}

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -113,14 +113,16 @@ def create_organizer_tables(syn, parent_id):
         parent=parent_id)
     table = synapseclient.Table(schema, [[]])
     table = syn.store(table)
-
+    logger.info("Created Table {}({})".format(table.name, table.id))
     for role in CHALLENGE_ROLES:
         view = synapseclient.MaterializedViewSchema(
             name=role.title() + 's',
             parent=parent_id,
             definingSQL=f"SELECT * FROM {table.id} WHERE challengeRole HAS ('{role}')"
         )
-        syn.store(view)
+        view = syn.store(view)
+        logger.info("Created MaterializedView {}({})".format(view.name, view.id))
+    return table
 
 
 def _create_live_wiki(syn, project):
@@ -253,7 +255,9 @@ def create_data_folders(syn, parent_id, tasks_count):
             name=f"Task {i + 1}",
             parent=parent_id
         )
-        syn.store(folder)
+        folder = syn.store(folder)
+        logger.info("Created Folder {}({})".format(folder.name, folder.id))
+    return
 
 
 def main(syn, challenge_name, tasks_count, live_site=None):

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -376,22 +376,27 @@ def main(syn, challenge_name, tasks_count, live_site=None):
         syn.store(wikipage)
 
     # Create another Task tab per task.
+    task_wikis = [
+        wiki.get('title')
+        for wiki in syn.getWikiHeaders(CHALLENGE_TEMPLATE_SYNID)
+        if wiki.get('parentId') == TASK_WIKI_ID
+    ]
     for i in range(1, tasks_count):
-        new_tab = synapseclient.Wiki(
-            title=f"Task {i + 1}",
+        new_task_tab = synapseclient.Wiki(
+            title=f"Task {i + 1} (tab)",
             owner=project_staging.id,
-            markdown="",
+            markdown="This page can be left empty - it will not appear on the portal.",
             parentWikiId=syn.getWiki(project_staging.id).id
         )
-        new_tab = syn.store(new_tab)
-        synapseutils.copyWiki(
-            syn,
-            CHALLENGE_TEMPLATE_SYNID,
-            project_staging.id,
-            entitySubPageId=TASK_WIKI_ID,
-            destinationSubPageId=new_tab.id,
-            entityMap={CHALLENGE_TEMPLATE_SYNID: project_staging.id}
-        )
+        new_task_tab = syn.store(new_task_tab)
+        for wiki_title in task_wikis:
+            task_subwiki = synapseclient.Wiki(
+                title=wiki_title,
+                owner=project_staging.id,
+                markdown="Refer to the Task 1 tab for examples",
+                parentWikiId=new_task_tab.id
+            )
+            syn.store(task_subwiki)
 
     return {
         "live_projectid": project_live.id,

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -240,6 +240,22 @@ def check_existing_and_delete_wiki(syn, synid):
             syn.delete(wiki)
 
 
+def create_data_folders(syn, parent_id, tasks_count):
+    """Create folders for challenge data, one for each task.
+    
+    Args:
+        syn: Synapse object
+        parent_id: project synID
+        tasks_count: Number of task folders to create        
+    """
+    for i in range(0, tasks_count):
+        folder = synapseclient.Folder(
+            name=f"Task {i + 1}",
+            parent=parent_id
+        )
+        syn.store(folder)
+
+
 def main(syn, challenge_name, tasks_count, live_site=None):
     """Creates two project entity for challenge sites.
     1) live (public) and 2) staging (private until launch)


### PR DESCRIPTION
## Changelog
* new module for creating a new challenge that conforms to the new Sage Challenge Portal.  Unlike `create-challenge`, this new module will:
   * use the [Challenge Portal Wiki Template](https://www.synapse.org/#!Synapse:syn52941681/wiki/624548) project as the template for staging
      * live will use a simple banner that says "More information coming soon":
      ![Screenshot 2023-11-22 at 2 34 15 PM](https://github.com/Sage-Bionetworks/challengeutils/assets/9377970/59639b72-dec7-4f02-bbb8-c27dc4ce6c7b)

   * create 2 teams instead of 4:
      * Organizers - will have "moderate" access to live, "edit" to staging
      * Participants
      * Preregistrants - ARCHIVED, has no purpose in the new portal
      * Admin - ARCHIVED, currently holds very little value
   * create one queue per task (based on `tasks_count`)
   * create one folder per task in live (based on `tasks_count`), where local sharing settings have been set:
      * Participants -  will have "download" access
   * create basic annotations for live project (based on [Challenge Portal Wiki Template's](https://www.synapse.org/#!Synapse:syn52941681/wiki/624548) annotations)

> [!NOTE]
> Default tables are not currently created, though the functionality _is_there.  For some reason, storing a new table will call on the __main__ module again, thus not finishing the create_portal_challenge module.
* add the newly-created live project to the [Curated Challenge Projects project view](https://www.synapse.org/#!Synapse:syn51476218/tables/), which currently powers the table.
   * Note: to actually _see_ the challenge on the portal, the "Status" annotation will need to be set to either: Active, Upcoming, or Completed 
* new CLI command: `create-portal-table`, e.g.

   ```
   challengeutils create-portal-table "challenge name" [-t <number of tasks (default: 1)>]
   ```

## Examples
**Example usage:**
```
$ challengeutils create-portal-challenge -h
usage: challengeutils create-portal-challenge [-h] [-t TASKS_COUNT] [--livesiteid LIVESITEID] challenge_name

positional arguments:
  challenge_name        Challenge name

options:
  -h, --help            show this help message and exit
  -t TASKS_COUNT, --tasks_count TASKS_COUNT
                        Number of challenge tasks (default: 1)
  --livesiteid LIVESITEID
                        Option to specify the live site synapse Id there is already a live site
```

**Create a new challenge called "Portal Test" which has 2 tasks:**
```
$ challengeutils create-portal-challenge "Portal Test" -t 2
INFO:challengeutils.create_portal_challenge: Team created: Portal Test Participants (3487214)
INFO:challengeutils.create_portal_challenge: Team created: Portal Test Organizers (3487215)
INFO:challengeutils.create_portal_challenge: Project created: Portal Test (syn53029636)
INFO:challengeutils.create_portal_challenge: Acivated as Challenge (ID: 4678)
INFO:challengeutils.create_portal_challenge: Queue created: Portal Test Task 1 (9615498)
INFO:challengeutils.create_portal_challenge: Queue created: Portal Test Task 2 (9615499)
INFO:challengeutils.create_portal_challenge: Creating folders...
INFO:challengeutils.create_portal_challenge:    Folder created: Task 1 (syn53029637) ✔
INFO:challengeutils.create_portal_challenge:    Folder created: Task 2 (syn53029638) ✔
 ...
 ...
INFO:challengeutils.create_portal_challenge: Creating basic annotations...
INFO:challengeutils.create_portal_challenge:    Annotations creation complete ✔
INFO:challengeutils.create_portal_challenge: Project created: Portal Test - staging (syn53029640)
INFO:challengeutils.create_portal_challenge: Copying wiki template to Portal Test - staging
 ...
 ...
INFO:challengeutils.create_portal_challenge: Challenge added to 'Curated Challenge Projects' (syn51476218)

Portal Test (Production site): https://www.synapse.org/#!Synapse:syn53029636
Portal Test (Staging site): https://www.synapse.org/#!Synapse:syn53029640
Portal Test (Participant team): https://www.synapse.org/#!Team:3487215
Portal Test (Organizer team): https://www.synapse.org/#!Team:3487214
```