### PR TITLE
[feat] update `create-challenge` commands

### DIFF
--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -1,4 +1,5 @@
 """challengeutils command line client"""
+
 import argparse
 import json
 import logging
@@ -6,19 +7,19 @@ import os
 
 import pandas as pd
 import synapseclient
+from synapseclient.core.exceptions import (
+    SynapseAuthenticationError,
+    SynapseNoCredentialsError,
+)
 from synapseclient.core.retry import with_retry
 from synapseclient.core.utils import from_unix_epoch_time
-from synapseclient.core.exceptions import (
-    SynapseNoCredentialsError,
-    SynapseAuthenticationError,
-)
 
 from . import (
     annotations,
-    createchallenge,
-    create_portal_challenge,
     challenge,
     cheat_detection,
+    create_portal_challenge,
+    createchallenge,
     evaluation_queue,
     mirrorwiki,
     permissions,
@@ -482,7 +483,7 @@ def build_parser():
     parser_create_portal_challenge.add_argument(
         "--livesiteid",
         help=(
-            "Option to specify the live site synapse Id" " there is already a live site"
+            "Option to specify the live site synapse Id there is already a live site"
         ),
     )
     parser_create_portal_challenge.add_argument(

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -50,13 +50,13 @@ def command_mirrorwiki(syn, args):
     )
 
 
-def command_createchallenge(syn, args):
+def command_create_challenge_legacy(syn, args):
     """Creates a challenge space in Synapse.  This pulls from a standard
     DREAM template and creates the Projects and Teams that you will need
     for a challenge.  For more information on all the components this function
     creates, please head to `challenge administration <https://docs.synapse.org/articles/challenge_administration.html>`_.
 
-    >>> challengeutils createchallenge "Challenge Name Here"
+    >>> challengeutils create-legacy-challenge "Challenge Name Here"
     """
     challenge_components = createchallenge.main(
         syn, args.challengename, args.livesiteid
@@ -82,10 +82,10 @@ def command_createchallenge(syn, args):
     return challenge_components
 
 
-def command_create_portal_challenge(syn, args):
+def command_create_challenge(syn, args):
     """Creates a challenge on the Sage Challenge Portal.
 
-    >>> challengeutils create-portal-challenge "Challenge Name Here" [-n <int>]
+    >>> challengeutils create-challenge "Challenge Name Here" [-n <int>]
     """
     challenge_components = create_portal_challenge.main(
         syn, args.challenge_name, args.tasks_count, args.livesiteid, args.private
@@ -455,21 +455,21 @@ def build_parser():
         help='For additional help: "challengeutils <COMMAND> -h"',
     )
 
-    parser_createchallenge = subparsers.add_parser(
-        "create-challenge", help="Creates a challenge from a template"
+    parser_create_legacy_challenge = subparsers.add_parser(
+        "create-challenge-legacy", help="Creates a challenge from a legacy template"
     )
-    parser_createchallenge.add_argument("challengename", help="Challenge name")
-    parser_createchallenge.add_argument(
+    parser_create_legacy_challenge.add_argument("challengename", help="Challenge name")
+    parser_create_legacy_challenge.add_argument(
         "--livesiteid",
         help=(
             "Option to specify the live site synapse Id" " there is already a live site"
         ),
     )
-    parser_createchallenge.set_defaults(func=command_createchallenge)
+    parser_create_legacy_challenge.set_defaults(func=command_create_challenge_legacy)
 
     parser_create_portal_challenge = subparsers.add_parser(
-        "create-portal-challenge",
-        help="Create a Sage Challenge Portal challenge from template",
+        "create-challenge",
+        help="(recommended) Create a challenge from the Sage Challenge Portal template",
     )
     parser_create_portal_challenge.add_argument("challenge_name", help="Challenge name")
     parser_create_portal_challenge.add_argument(

--- a/challengeutils/__main__.py
+++ b/challengeutils/__main__.py
@@ -88,7 +88,7 @@ def command_create_portal_challenge(syn, args):
     >>> challengeutils create-portal-challenge "Challenge Name Here" [-n <int>]
     """
     challenge_components = create_portal_challenge.main(
-        syn, args.challenge_name, args.tasks_count, args.livesiteid
+        syn, args.challenge_name, args.tasks_count, args.livesiteid, args.private
     )
     # component: project or team
     # componentid: project id or teamid
@@ -485,7 +485,11 @@ def build_parser():
             "Option to specify the live site synapse Id" " there is already a live site"
         ),
     )
-    parser_create_portal_challenge.set_defaults(func=command_create_portal_challenge)
+    parser_create_portal_challenge.add_argument(
+        "--private",
+        help="Option to not share the challenge with the Sage CNB Team",
+    )
+    parser_create_portal_challenge.set_defaults(func=command_create_challenge)
 
     parser_mirrorwiki = subparsers.add_parser(
         "mirror-wiki",

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -342,12 +342,14 @@ def main(syn, challenge_name, tasks_count, live_site=None, private=False):
 
     challenge_obj = create_challenge_widget(syn, project_live, teams["team_part_id"])
     for i in range(0, tasks_count):
-        create_evaluation_queue(
+        queue = create_evaluation_queue(
             syn,
             f"{challenge_name} Task {i + 1}",
             f"Task {i + 1} Submission",
             project_live.id,
         )
+        if not private:
+            permissions.set_evaluation_permissions(syn, queue, SAGE_CNB_TEAM, "admin")
     # TODO: the following function does not work for some reason; see function
     #       for details
     # tables = create_organizer_tables(syn, project_live.id)

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -13,12 +13,13 @@ Example::
     challengeutils.create_portal_challenge.main(syn, "Foo Challenge")
 
 """
+
 import logging
 import sys
 
 import synapseclient
-from synapseclient.core.exceptions import SynapseHTTPError
 import synapseutils
+from synapseclient.core.exceptions import SynapseHTTPError
 
 from . import challenge, permissions
 

--- a/challengeutils/create_portal_challenge.py
+++ b/challengeutils/create_portal_challenge.py
@@ -29,6 +29,7 @@ CHALLENGE_TEMPLATE_SYNID = "syn52941681"
 TABLE_TEMPLATE_SYNID = "syn52955244"
 CHALLENGE_ROLES = ["organizer", "contributor", "sponsor"]
 TASK_WIKI_ID = "624554"
+SAGE_CNB_TEAM = "3379097"
 
 
 def create_project(syn, project_name):
@@ -299,7 +300,7 @@ def create_annotations(syn, project_id, table_ids, folder_ids):
     return project
 
 
-def main(syn, challenge_name, tasks_count, live_site=None):
+def main(syn, challenge_name, tasks_count, live_site=None, private=False):
     """Creates two project entity for challenge sites.
     1) live (public) and 2) staging (private until launch)
     Allow for users to set up the live site themselves
@@ -331,6 +332,10 @@ def main(syn, challenge_name, tasks_count, live_site=None):
         permissions.set_entity_permissions(
             syn, project_live, teams["team_org_id"], permission_level="moderate"
         )
+        if not private:
+            permissions.set_entity_permissions(
+                syn, project_live, SAGE_CNB_TEAM, "admin"
+            )
         _create_live_wiki(syn, project_live)
     else:
         project_live = syn.get(live_site)
@@ -369,6 +374,8 @@ def main(syn, challenge_name, tasks_count, live_site=None):
     permissions.set_entity_permissions(
         syn, project_staging, teams["team_org_id"], permission_level="edit"
     )
+    if not private:
+        permissions.set_entity_permissions(syn, project_staging, SAGE_CNB_TEAM, "admin")
     # Checks if staging wiki exists, if so delete
     check_existing_and_delete_wiki(syn, project_staging.id)
 


### PR DESCRIPTION
## Changelog

- add the [Sage CNB Team](https://www.synapse.org/Team:3379097) as admin to all challenges created by the tool
- add `private` option to the `create-challenge` command to allow organizers the option to not add the Sage CNB Team, e.g.

   ```
   $ challengeutils create-challenge \
      challenge_name \
      [-t TASKS_COUNT] \
      [--livesiteid LIVESITEID] \
      [--private PRIVATE]
   ```

- update CLI command name for `create-portal-challenge` to `create-challenge`
   - That way, newer challenges created will use the template that is better ported over to the Sage Challenge Portal
- update CLI command name for `create-challenge` to `create-challenge-legacy`  
- general linting